### PR TITLE
Add index, index schema with query & scan support

### DIFF
--- a/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
+++ b/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
@@ -116,7 +116,7 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     queryPaginator(
       table.client.underlying.queryAsync,
-      Aws1IndexOps(table).query(pk, condition, consistent, resolvedOverride),
+      Aws1IndexOps(table).queryPK(pk, condition, consistent, resolvedOverride),
       limit
     )
       .mapConcat { data => Aws1IndexOps(table).deserialize(data) }

--- a/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
+++ b/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
@@ -8,7 +8,7 @@ import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.dynamodbv2.model._
 import com.hiya.alternator.akka.internal.AkkaBase
 import com.hiya.alternator.aws1.internal.Aws1DynamoDB
-import com.hiya.alternator.aws1.{Aws1DynamoDBClient, Aws1IndexOps, Aws1TableOps, Aws1TableWithRangeKeyOps}
+import com.hiya.alternator.aws1.{Aws1DynamoDBClient, Aws1IndexOps, Aws1TableLikeOps, Aws1TableWithRangeLikeOps}
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
 import com.hiya.alternator.{DynamoDBOverride, Index, TableLike, TableWithRangeLike}
@@ -58,10 +58,10 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     scanPaginator(
       table.client.underlying.scanAsync,
-      Aws1TableOps(table).scan(segment, condition, consistent, resolvedOverride),
+      Aws1TableLikeOps(table).scan(segment, condition, consistent, resolvedOverride),
       limit
     )
-      .mapConcat(data => Aws1TableOps(table).deserialize(data))
+      .mapConcat(data => Aws1TableLikeOps(table).deserialize(data))
   }
 
   private def queryPaginator(
@@ -99,10 +99,10 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     queryPaginator(
       table.client.underlying.queryAsync,
-      Aws1TableWithRangeKeyOps(table).query(pk, rk, condition, consistent, resolvedOverride),
+      Aws1TableWithRangeLikeOps(table).query(pk, rk, condition, consistent, resolvedOverride),
       limit
     )
-      .mapConcat { data => Aws1TableWithRangeKeyOps(table).deserialize(data) }
+      .mapConcat { data => Aws1TableWithRangeLikeOps(table).deserialize(data) }
   }
 
   override def queryPK[V, PK](

--- a/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
+++ b/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
@@ -6,10 +6,10 @@ import cats.instances.future._
 import cats.syntax.all._
 import com.hiya.alternator.akka.internal.AkkaBase
 import com.hiya.alternator.aws2.internal.Aws2DynamoDB
-import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2TableOps, Aws2TableWithRangeKeyOps}
+import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2IndexOps, Aws2TableOps, Aws2TableWithRangeKeyOps}
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
-import com.hiya.alternator.{DynamoDBOverride, Table, TableWithRange}
+import com.hiya.alternator.{DynamoDBOverride, Index, TableLike, TableWithRangeLike}
 import software.amazon.awssdk.services.dynamodb.model.{QueryRequest, QueryResponse, ScanRequest, ScanResponse}
 
 import java.util.concurrent.{CompletableFuture, CompletionException}
@@ -51,7 +51,7 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
   }
 
   override def scan[V, PK](
-    table: Table[Aws2DynamoDBClient, V, PK],
+    table: TableLike[Aws2DynamoDBClient, V, PK],
     segment: Option[Segment],
     condition: Option[ConditionExpression[Boolean]],
     limit: Option[Int] = None,
@@ -91,7 +91,7 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
   }
 
   override def query[V, PK, RK](
-    table: TableWithRange[Aws2DynamoDBClient, V, PK, RK],
+    table: TableWithRangeLike[Aws2DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
     condition: Option[ConditionExpression[Boolean]],
@@ -107,6 +107,24 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
         .limit(limit.map(Int.box).orNull),
       limit
     ).mapConcat(data => Aws2TableWithRangeKeyOps(table).deserialize(data))
+  }
+
+  override def queryPK[V, PK](
+    table: Index[Aws2DynamoDBClient, V, PK],
+    pk: PK,
+    condition: Option[ConditionExpression[Boolean]],
+    limit: Option[Int],
+    consistent: Boolean,
+    overrides: DynamoDBOverride[Aws2DynamoDBClient]
+  ): Source[Result[V]] = {
+    val resolvedOverride = (table.overrides |+| overrides)(table.client)
+    queryPaginator(
+      table.client.client.query,
+      Aws2IndexOps(table)
+        .query(pk, condition, consistent, resolvedOverride)
+        .limit(limit.map(Int.box).orNull),
+      limit
+    ).mapConcat(data => Aws2IndexOps(table).deserialize(data))
   }
 }
 

--- a/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
+++ b/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
@@ -6,7 +6,7 @@ import cats.instances.future._
 import cats.syntax.all._
 import com.hiya.alternator.akka.internal.AkkaBase
 import com.hiya.alternator.aws2.internal.Aws2DynamoDB
-import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2IndexOps, Aws2TableOps, Aws2TableWithRangeKeyOps}
+import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2IndexOps, Aws2TableLikeOps, Aws2TableWithRangeLikeOps}
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
 import com.hiya.alternator.{DynamoDBOverride, Index, TableLike, TableWithRangeLike}
@@ -61,9 +61,9 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     scanPaginator(
       table.client.client.scan,
-      Aws2TableOps(table).scan(segment, condition, consistent, resolvedOverride),
+      Aws2TableLikeOps(table).scan(segment, condition, consistent, resolvedOverride),
       limit
-    ).mapConcat(data => Aws2TableOps(table).deserialize(data))
+    ).mapConcat(data => Aws2TableLikeOps(table).deserialize(data))
   }
 
   private def queryPaginator(
@@ -102,11 +102,11 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     queryPaginator(
       table.client.client.query,
-      Aws2TableWithRangeKeyOps(table)
+      Aws2TableWithRangeLikeOps(table)
         .query(pk, rk, condition, consistent, resolvedOverride)
         .limit(limit.map(Int.box).orNull),
       limit
-    ).mapConcat(data => Aws2TableWithRangeKeyOps(table).deserialize(data))
+    ).mapConcat(data => Aws2TableWithRangeLikeOps(table).deserialize(data))
   }
 
   override def queryPK[V, PK](

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
@@ -37,7 +37,7 @@ class Aws1IndexOps[V, PK](val underlying: Index[Aws1DynamoDBClient, V, PK])
   }
 
   final def deserialize(response: model.QueryResult): List[DynamoFormat.Result[V]] = {
-    Option(response.getItems).toList.flatMap(_.asScala.toList.map(Aws1TableOps(underlying).deserialize))
+    Option(response.getItems).toList.flatMap(_.asScala.toList.map(Aws1TableLikeOps(underlying).deserialize))
   }
 }
 

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
@@ -14,7 +14,7 @@ class Aws1IndexOps[V, PK](val underlying: Index[Aws1DynamoDBClient, V, PK])
 
   import underlying._
 
-  def query(
+  def queryPK(
     pk: PK,
     condition: Option[ConditionExpression[_]],
     consistent: Boolean,

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableLikeOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableLikeOps.scala
@@ -1,0 +1,43 @@
+package com.hiya.alternator.aws1
+
+import com.amazonaws.services.dynamodbv2.model._
+import com.hiya.alternator.internal.{ConditionalSupport, OptApp}
+import com.hiya.alternator.schema.DynamoFormat
+import com.hiya.alternator.syntax.{ConditionExpression, Segment}
+import com.hiya.alternator.{DynamoDBOverride, TableLike}
+
+import scala.jdk.CollectionConverters._
+
+final class Aws1TableLikeOps[V, PK](val underlying: TableLike[_, V, PK]) {
+  final def deserialize(response: java.util.Map[String, AttributeValue]): DynamoFormat.Result[V] = {
+    underlying.schema.serializeValue.readFields(response)
+  }
+
+  final def deserialize(response: ScanResult): List[DynamoFormat.Result[V]] = {
+    Option(response.getItems).toList.flatMap(_.asScala.toList.map(deserialize))
+  }
+
+  final def scan(
+    segment: Option[Segment] = None,
+    condition: Option[ConditionExpression[Boolean]],
+    consistent: Boolean,
+    overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
+  ): ScanRequest = {
+    val request = new ScanRequest(underlying.tableName)
+      .optApp(_.withIndexName)(underlying.indexNameOpt)
+      .optApp(req =>
+        (segment: Segment) => {
+          req.withSegment(segment.segment).withTotalSegments(segment.totalSegments)
+        }
+      )(segment)
+      .withConsistentRead(consistent)
+      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+
+    overrides(request).asInstanceOf[ScanRequest]
+  }
+}
+
+object Aws1TableLikeOps {
+  @inline def apply[V, PK](underlying: TableLike[_, V, PK]): Aws1TableLikeOps[V, PK] =
+    new Aws1TableLikeOps[V, PK](underlying)
+}

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableWithRangeLikeOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableWithRangeLikeOps.scala
@@ -9,7 +9,7 @@ import com.hiya.alternator.{DynamoDBOverride, TableWithRangeLike}
 
 import scala.jdk.CollectionConverters._
 
-class Aws1TableWithRangeKeyOps[V, PK, RK](val underlying: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK])
+class Aws1TableWithRangeLikeOps[V, PK, RK](val underlying: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK])
   extends AnyVal {
 
   import underlying._
@@ -38,11 +38,11 @@ class Aws1TableWithRangeKeyOps[V, PK, RK](val underlying: TableWithRangeLike[Aws
   }
 
   final def deserialize(response: model.QueryResult): List[DynamoFormat.Result[V]] = {
-    Option(response.getItems).toList.flatMap(_.asScala.toList.map(Aws1TableOps(underlying).deserialize))
+    Option(response.getItems).toList.flatMap(_.asScala.toList.map(Aws1TableLikeOps(underlying).deserialize))
   }
 }
 
-object Aws1TableWithRangeKeyOps {
+object Aws1TableWithRangeLikeOps {
   @inline def apply[V, PK, RK](underlying: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK]) =
-    new Aws1TableWithRangeKeyOps(underlying)
+    new Aws1TableWithRangeLikeOps(underlying)
 }

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
@@ -131,6 +131,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
     readCapacity: Long,
     writeCapacity: Long,
     attributes: List[(String, ScalarType)],
+    globalSecondaryIndexes: List[com.hiya.alternator.GlobalSecondaryIndex],
     overrides: DynamoDBOverride[Client]
   ): F[Unit] = {
     val resolvedOverride = overrides.apply(client)
@@ -143,6 +144,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
           readCapacity,
           writeCapacity,
           attributes,
+          globalSecondaryIndexes,
           resolvedOverride
         ),
         _: AsyncHandler[CreateTableRequest, CreateTableResult]

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
@@ -38,7 +38,7 @@ class Aws2IndexOps[V, PK](val underlying: Aws2Index[V, PK]) extends AnyVal {
   }
 
   final def deserialize(response: model.QueryResponse): List[DynamoFormat.Result[V]] = {
-    if (response.hasItems) response.items().asScala.toList.map(Aws2TableOps(underlying).deserialize)
+    if (response.hasItems) response.items().asScala.toList.map(Aws2TableLikeOps(underlying).deserialize)
     else Nil
   }
 }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
@@ -4,20 +4,19 @@ import cats.syntax.all._
 import com.hiya.alternator.DynamoDBOverride
 import com.hiya.alternator.internal._
 import com.hiya.alternator.schema.DynamoFormat
-import com.hiya.alternator.syntax.{ConditionExpression, RKCondition}
+import com.hiya.alternator.syntax.ConditionExpression
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration
 import software.amazon.awssdk.services.dynamodb.model
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 
 import scala.jdk.CollectionConverters._
 
-class Aws2TableWithRangeKeyOps[V, PK, RK](val underlying: Aws2TableWithRangeLike[V, PK, RK]) extends AnyVal {
+class Aws2IndexOps[V, PK](val underlying: Aws2Index[V, PK]) extends AnyVal {
 
   import underlying._
 
   def query(
     pk: PK,
-    rk: RKCondition[RK] = RKCondition.Empty,
     condition: Option[ConditionExpression[Boolean]],
     consistent: Boolean = false,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
@@ -25,13 +24,13 @@ class Aws2TableWithRangeKeyOps[V, PK, RK](val underlying: Aws2TableWithRangeLike
     val request: QueryRequest.Builder = model.QueryRequest
       .builder()
       .tableName(tableName)
-      .optApp(_.indexName)(underlying.indexNameOpt)
+      .indexName(underlying.indexName)
       .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
       .consistentRead(consistent)
 
     Condition.eval {
       for {
-        keyCondition <- Condition.renderCondition[model.AttributeValue, PK, RK](pk, rk, schema)
+        keyCondition <- Condition.renderPKCondition[model.AttributeValue, PK](pk, schema)
         filter <- condition.traverse(Condition.renderCondition(_))
         builder <- Condition.execute(request)
       } yield builder.keyConditionExpression(keyCondition).filterExpression(filter.orNull)
@@ -44,7 +43,7 @@ class Aws2TableWithRangeKeyOps[V, PK, RK](val underlying: Aws2TableWithRangeLike
   }
 }
 
-object Aws2TableWithRangeKeyOps {
-  @inline def apply[V, PK, RK](underlying: Aws2TableWithRangeLike[V, PK, RK]) =
-    new Aws2TableWithRangeKeyOps(underlying)
+object Aws2IndexOps {
+  @inline def apply[V, PK, RK](underlying: Aws2Index[V, PK]) =
+    new Aws2IndexOps(underlying)
 }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableLikeOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableLikeOps.scala
@@ -1,0 +1,48 @@
+package com.hiya.alternator.aws2
+
+import com.hiya.alternator._
+import com.hiya.alternator.internal._
+import com.hiya.alternator.schema.DynamoFormat
+import com.hiya.alternator.syntax.{ConditionExpression, Segment}
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration
+import software.amazon.awssdk.services.dynamodb.model._
+
+import scala.jdk.CollectionConverters._
+
+class Aws2TableLikeOps[V, PK](val underlying: TableLike[Aws2DynamoDBClient, V, PK]) extends AnyVal {
+  import underlying._
+
+  final def deserialize(response: java.util.Map[String, AttributeValue]): DynamoFormat.Result[V] = {
+    schema.serializeValue.readFields(response)
+  }
+
+  final def deserialize(response: ScanResponse): List[DynamoFormat.Result[V]] = {
+    if (response.hasItems) response.items().asScala.toList.map(deserialize)
+    else Nil
+  }
+
+  final def scan(
+    segment: Option[Segment] = None,
+    condition: Option[ConditionExpression[Boolean]],
+    consistent: Boolean,
+    overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
+  ): ScanRequest.Builder = {
+    val request = ScanRequest
+      .builder()
+      .tableName(tableName)
+      .optApp(_.indexName)(underlying.indexNameOpt)
+      .optApp(req => (segment: Segment) => req.segment(segment.segment).totalSegments(segment.totalSegments))(segment)
+      .consistentRead(consistent)
+      .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
+
+    condition match {
+      case Some(cond) => ConditionalSupport.eval(request, cond)
+      case None => request
+    }
+  }
+
+}
+
+object Aws2TableLikeOps {
+  @inline def apply[V, PK](underlying: Aws2TableLike[V, PK]): Aws2TableLikeOps[V, PK] = new Aws2TableLikeOps(underlying)
+}

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
@@ -5,7 +5,7 @@ import com.hiya.alternator.internal._
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.{DynamoFormat, ScalarType}
 import com.hiya.alternator.syntax.{ConditionExpression, Segment}
-import com.hiya.alternator.{BatchReadResult, BatchWriteResult, DynamoDBOverride, Table}
+import com.hiya.alternator.{BatchReadResult, BatchWriteResult, DynamoDBOverride, Table, TableLike}
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration
 import software.amazon.awssdk.services.dynamodb.model._
 
@@ -84,7 +84,7 @@ object Aws2BatchRead {
   def apply(response: BatchGetItemResponse): Aws2BatchRead = new Aws2BatchRead(response)
 }
 
-class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) extends AnyVal {
+class Aws2TableOps[V, PK](val underlying: TableLike[Aws2DynamoDBClient, V, PK]) extends AnyVal {
   import underlying._
 
   final def deserialize(response: Aws2TableOps.AV): DynamoFormat.Result[V] = {
@@ -122,6 +122,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
     val request = ScanRequest
       .builder()
       .tableName(tableName)
+      .optApp(_.indexName)(underlying.indexNameOpt)
       .optApp(req => (segment: Segment) => req.segment(segment.segment).totalSegments(segment.totalSegments))(segment)
       .consistentRead(consistent)
       .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
@@ -214,7 +215,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
 object Aws2TableOps {
   type AV = java.util.Map[String, AttributeValue]
 
-  @inline def apply[V, PK](underlying: Aws2Table[V, PK]): Aws2TableOps[V, PK] = new Aws2TableOps(underlying)
+  @inline def apply[V, PK](underlying: Aws2TableLike[V, PK]): Aws2TableOps[V, PK] = new Aws2TableOps(underlying)
 
   def dropTable(
     tableName: String,
@@ -232,6 +233,7 @@ object Aws2TableOps {
     readCapacity: Long,
     writeCapacity: Long,
     attributes: List[(String, ScalarType)],
+    globalSecondaryIndexes: List[com.hiya.alternator.GlobalSecondaryIndex],
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): CreateTableRequest.Builder = {
     val keySchema: List[KeySchemaElement] = {
@@ -246,6 +248,35 @@ object Aws2TableOps {
       .attributeDefinitions(attributes.map { case (name, scalarType) =>
         AttributeDefinition.builder().attributeName(name).attributeType(scalarType).build()
       }.asJava)
+      .optApp(req => (gsis: List[GlobalSecondaryIndex]) => req.globalSecondaryIndexes(gsis.asJava))(
+        globalSecondaryIndexes match {
+          case Nil => None
+          case gsis =>
+            Some(
+              gsis.map { gsi =>
+                val keySchema: List[KeySchemaElement] = {
+                  KeySchemaElement.builder().attributeName(gsi.partitionKeyName).keyType(KeyType.HASH).build() ::
+                    gsi.rangeKeyName
+                      .map(key => KeySchemaElement.builder().attributeName(key).keyType(KeyType.RANGE).build())
+                      .toList
+                }
+                GlobalSecondaryIndex
+                  .builder()
+                  .indexName(gsi.indexName)
+                  .keySchema(keySchema.asJava)
+                  .provisionedThroughput(
+                    ProvisionedThroughput
+                      .builder()
+                      .readCapacityUnits(readCapacity)
+                      .writeCapacityUnits(writeCapacity)
+                      .build()
+                  )
+                  .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                  .build()
+              }
+            )
+        }
+      )
       .provisionedThroughput(
         ProvisionedThroughput.builder().readCapacityUnits(readCapacity).writeCapacityUnits(writeCapacity).build()
       )

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableWithRangeLikeOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableWithRangeLikeOps.scala
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.dynamodb.model.QueryRequest
 
 import scala.jdk.CollectionConverters._
 
-class Aws2TableWithRangeKeyOps[V, PK, RK](val underlying: Aws2TableWithRangeLike[V, PK, RK]) extends AnyVal {
+class Aws2TableWithRangeLikeOps[V, PK, RK](val underlying: Aws2TableWithRangeLike[V, PK, RK]) extends AnyVal {
 
   import underlying._
 
@@ -39,12 +39,12 @@ class Aws2TableWithRangeKeyOps[V, PK, RK](val underlying: Aws2TableWithRangeLike
   }
 
   final def deserialize(response: model.QueryResponse): List[DynamoFormat.Result[V]] = {
-    if (response.hasItems) response.items().asScala.toList.map(Aws2TableOps(underlying).deserialize)
+    if (response.hasItems) response.items().asScala.toList.map(Aws2TableLikeOps(underlying).deserialize)
     else Nil
   }
 }
 
-object Aws2TableWithRangeKeyOps {
+object Aws2TableWithRangeLikeOps {
   @inline def apply[V, PK, RK](underlying: Aws2TableWithRangeLike[V, PK, RK]) =
-    new Aws2TableWithRangeKeyOps(underlying)
+    new Aws2TableWithRangeLikeOps(underlying)
 }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
@@ -120,11 +120,12 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
     readCapacity: Long,
     writeCapacity: Long,
     attributes: List[(String, ScalarType)],
+    globalSecondaryIndexes: List[GlobalSecondaryIndex] = Nil,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
   ): F[Unit] = {
     val resolvedOverride = overrides(client)
     val req = Aws2TableOps
-      .createTable(tableName, hashKey, rangeKey, readCapacity, writeCapacity, attributes, resolvedOverride)
+      .createTable(tableName, hashKey, rangeKey, readCapacity, writeCapacity, attributes, globalSecondaryIndexes, resolvedOverride)
       .build()
     async(client.client.createTable(req)).map(_ => ())
   }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/package.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/package.scala
@@ -21,7 +21,10 @@ import scala.jdk.CollectionConverters._
 
 package object aws2 {
   type Aws2Table[V, PK] = Table[Aws2DynamoDBClient, V, PK]
+  type Aws2TableLike[V, PK] = TableLike[Aws2DynamoDBClient, V, PK]
   type Aws2TableWithRange[V, PK, RK] = TableWithRange[Aws2DynamoDBClient, V, PK, RK]
+  type Aws2TableWithRangeLike[V, PK, RK] = TableWithRangeLike[Aws2DynamoDBClient, V, PK, RK]
+  type Aws2Index[V, PK] = Index[Aws2DynamoDBClient, V, PK]
   type Aws2DynamoDB[F[_]] = DynamoDB.Client[F, DynamoDbAsyncClient]
 
   implicit object PutIsConditional extends ConditionalSupport[model.PutItemRequest.Builder, model.AttributeValue] {

--- a/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
+++ b/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
@@ -6,7 +6,7 @@ import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.dynamodbv2.model.{QueryRequest, QueryResult, ScanRequest, ScanResult}
 import com.hiya.alternator.aws1.internal.Aws1DynamoDB
-import com.hiya.alternator.aws1.{Aws1DynamoDBClient, Aws1IndexOps, Aws1TableOps, Aws1TableWithRangeKeyOps}
+import com.hiya.alternator.aws1.{Aws1DynamoDBClient, Aws1IndexOps, Aws1TableLikeOps, Aws1TableWithRangeLikeOps}
 import com.hiya.alternator.cats.internal.CatsBase
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
@@ -61,10 +61,10 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
     val resolvedOverride = (table.overrides |+| overrides).apply(table.client)
     scanPaginator(
       table.client.underlying.scanAsync,
-      Aws1TableOps(table).scan(segment, condition, consistent, resolvedOverride),
+      Aws1TableLikeOps(table).scan(segment, condition, consistent, resolvedOverride),
       limit
     )
-      .flatMap(data => Stream.emits(Aws1TableOps(table).deserialize(data)))
+      .flatMap(data => Stream.emits(Aws1TableLikeOps(table).deserialize(data)))
   }
 
   private def queryPaginator(
@@ -100,10 +100,10 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
     val resolvedOverride = (table.overrides |+| overrides).apply(table.client)
     queryPaginator(
       table.client.underlying.queryAsync,
-      Aws1TableWithRangeKeyOps(table).query(pk, rk, condition, consistent, resolvedOverride),
+      Aws1TableWithRangeLikeOps(table).query(pk, rk, condition, consistent, resolvedOverride),
       limit
     )
-      .flatMap { data => fs2.Stream.emits(Aws1TableWithRangeKeyOps(table).deserialize(data)) }
+      .flatMap { data => fs2.Stream.emits(Aws1TableWithRangeLikeOps(table).deserialize(data)) }
   }
 
   override def queryPK[V, PK](

--- a/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
+++ b/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
@@ -117,7 +117,7 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
     val resolvedOverride = (table.overrides |+| overrides).apply(table.client)
     queryPaginator(
       table.client.underlying.queryAsync,
-      Aws1IndexOps(table).query(pk, condition, consistent, resolvedOverride),
+      Aws1IndexOps(table).queryPK(pk, condition, consistent, resolvedOverride),
       limit
     )
       .flatMap { data => fs2.Stream.emits(Aws1IndexOps(table).deserialize(data)) }

--- a/cats-aws2/src/main/scala/com/hiya/alternator/cats/CatsAws2.scala
+++ b/cats-aws2/src/main/scala/com/hiya/alternator/cats/CatsAws2.scala
@@ -4,7 +4,7 @@ import _root_.cats.effect._
 import _root_.cats.syntax.all._
 import com.hiya.alternator._
 import com.hiya.alternator.aws2.internal.Aws2DynamoDB
-import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2IndexOps, Aws2TableOps, Aws2TableWithRangeKeyOps}
+import com.hiya.alternator.aws2.{Aws2DynamoDBClient, Aws2IndexOps, Aws2TableLikeOps, Aws2TableWithRangeLikeOps}
 import com.hiya.alternator.cats.internal.CatsBase
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
@@ -53,10 +53,10 @@ class CatsAws2[F[+_]](protected override implicit val F: Async[F])
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     scanPaginator(
       table.client.client.scan,
-      Aws2TableOps(table).scan(segment, condition, consistent, resolvedOverride),
+      Aws2TableLikeOps(table).scan(segment, condition, consistent, resolvedOverride),
       limit
     )
-      .flatMap(data => Stream.emits(Aws2TableOps(table).deserialize(data)))
+      .flatMap(data => Stream.emits(Aws2TableLikeOps(table).deserialize(data)))
   }
 
   private def queryPaginator(
@@ -93,9 +93,9 @@ class CatsAws2[F[+_]](protected override implicit val F: Async[F])
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     queryPaginator(
       table.client.client.query,
-      Aws2TableWithRangeKeyOps(table).query(pk, rk, condition, consistent, resolvedOverride),
+      Aws2TableWithRangeLikeOps(table).query(pk, rk, condition, consistent, resolvedOverride),
       limit
-    ).flatMap { data => fs2.Stream.emits(Aws2TableWithRangeKeyOps(table).deserialize(data)) }
+    ).flatMap { data => fs2.Stream.emits(Aws2TableWithRangeLikeOps(table).deserialize(data)) }
   }
 
   override def queryPK[V, PK](

--- a/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
+++ b/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
@@ -72,7 +72,7 @@ trait DynamoDBSource {
   type Monad[_]
 
   def scan[V, PK](
-    table: Table[Client, V, PK],
+    table: TableLike[Client, V, PK],
     segment: Option[Segment] = None,
     condition: Option[ConditionExpression[Boolean]] = None,
     limit: Option[Int] = None,
@@ -81,9 +81,18 @@ trait DynamoDBSource {
   ): Source[Result[V]]
 
   def query[V, PK, RK](
-    table: TableWithRange[Client, V, PK, RK],
+    table: TableWithRangeLike[Client, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK] = RKCondition.Empty,
+    condition: Option[ConditionExpression[Boolean]] = None,
+    limit: Option[Int] = None,
+    consistent: Boolean = false,
+    overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
+  ): Source[Result[V]]
+
+  def queryPK[V, PK](
+    table: Index[Client, V, PK],
+    pk: PK,
     condition: Option[ConditionExpression[Boolean]] = None,
     limit: Option[Int] = None,
     consistent: Boolean = false,
@@ -341,6 +350,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
     readCapacity: Long = 1L,
     writeCapacity: Long = 1L,
     attributes: List[(String, ScalarType)] = Nil,
+    globalSecondaryIndexes: List[GlobalSecondaryIndex] = Nil,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
   ): F[Unit]
 

--- a/core/src/main/scala/com/hiya/alternator/GlobalSecondaryIndex.scala
+++ b/core/src/main/scala/com/hiya/alternator/GlobalSecondaryIndex.scala
@@ -1,0 +1,7 @@
+package com.hiya.alternator
+
+final case class GlobalSecondaryIndex(
+  indexName: String,
+  partitionKeyName: String,
+  rangeKeyName: Option[String] = None
+)

--- a/core/src/main/scala/com/hiya/alternator/internal/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/internal/package.scala
@@ -3,7 +3,7 @@ package com.hiya.alternator
 import cats.FlatMap
 import cats.data.State
 import cats.syntax.all._
-import com.hiya.alternator.schema.{AttributeValue, TableSchemaWithRange}
+import com.hiya.alternator.schema.{AttributeValue, TableSchemaWithPartition, TableSchemaWithRange}
 import com.hiya.alternator.syntax.ConditionExpression._
 import com.hiya.alternator.syntax.{ConditionExpression, RKCondition}
 
@@ -107,6 +107,12 @@ package object internal {
       }
     }
 
+    def renderPKCondition[AV: AttributeValue, PK](
+      pk: PK,
+      schema: TableSchemaWithPartition.Aux[_, PK]
+    ): Condition[AV, String] = {
+      nonemptyCondition(RKCondition.EQ(pk)(schema.PK), schema.pkField)
+    }
   }
 
   implicit class OptApp[T](underlying: T) {

--- a/core/src/main/scala/com/hiya/alternator/schema/IndexSchema.scala
+++ b/core/src/main/scala/com/hiya/alternator/schema/IndexSchema.scala
@@ -1,0 +1,68 @@
+package com.hiya.alternator.schema
+import com.hiya.alternator.schema.DynamoFormat.Result
+
+import java.util
+
+final case class IndexSchema[V, PK](
+  indexName: String,
+  schema: TableSchemaWithPartition.Aux[V, PK]
+)
+
+object IndexSchema {
+  def onTable[V, PKType](tableSchema: TableSchema.Aux[V, _])(
+    indexName: String,
+    pkField: String,
+    extractPK: V => PKType
+  )(implicit
+    PKType: ScalarDynamoFormat[PKType]
+  ): IndexSchema[V, PKType] = {
+    val underlying = TableSchema.schemaWithPK(pkField, extractPK)(PKType, tableSchema.serializeValue)
+    val schema = new TableSchemaWithPartition[V](tableSchema.serializeValue, pkField) {
+
+      override type PK = PKType
+      override def PK: ScalarDynamoFormat[PKType] = PKType
+
+      override def serializePK[AV: AttributeValue](pk: PKType): util.Map[String, AV] = underlying.serializePK(pk)
+      override def extract[AV: AttributeValue](av: util.Map[String, AV]): Result[PKType] = underlying.extract(av)
+      override def extract(value: V): PKType = underlying.extract(value)
+      override def schema: List[(String, ScalarType)] = underlying.schema
+    }
+
+    IndexSchema(indexName, schema)
+  }
+}
+
+final case class IndexSchemaWithRange[V, PKType, RKType](
+  indexName: String,
+  schema: TableSchemaWithRange.Aux[V, PKType, RKType]
+)
+
+object IndexSchemaWithRange {
+  def onTable[V, PKType, RKType](tableSchema: TableSchema.Aux[V, _])(
+    indexName: String,
+    pkField: String,
+    rkField: String,
+    extractKey: V => (PKType, RKType)
+  )(implicit
+    PKType: ScalarDynamoFormat[PKType],
+    RKType: ScalarDynamoFormat[RKType]
+  ): IndexSchemaWithRange[V, PKType, RKType] = {
+    val underlying = TableSchema.schemaWithRK(pkField, rkField, extractKey)(tableSchema.serializeValue, PKType, RKType)
+    val schema = new TableSchemaWithRange[V](tableSchema.serializeValue, pkField, rkField) {
+
+      override type PK = PKType
+      override def PK: ScalarDynamoFormat[PKType] = PKType
+
+      override type RK = RKType
+      override def RK: ScalarDynamoFormat[RKType] = RKType
+
+      override def serializePK[AV: AttributeValue](pk: IndexType): util.Map[String, AV] = underlying.serializePK(pk)
+      override def extract[AV: AttributeValue](av: util.Map[String, AV]): Result[IndexType] = underlying.extract(av)
+      override def extract(value: V): IndexType = underlying.extract(value)
+      override def schema: List[(String, ScalarType)] = underlying.schema
+    }
+
+    IndexSchemaWithRange(indexName, schema)
+  }
+
+}

--- a/core/src/main/scala/com/hiya/alternator/schema/TableSchemaWithPartition.scala
+++ b/core/src/main/scala/com/hiya/alternator/schema/TableSchemaWithPartition.scala
@@ -1,0 +1,18 @@
+package com.hiya.alternator.schema
+
+abstract class TableSchemaWithPartition[V](
+  serializeValue: RootDynamoFormat[V],
+  val pkField: String,
+) extends TableSchema[V](serializeValue) {
+
+  type PK
+  def PK: ScalarDynamoFormat[PK]
+
+  override type IndexType = PK
+}
+
+object TableSchemaWithPartition {
+  type Aux[V, PKType] = TableSchemaWithPartition[V] {
+    type PK = PKType
+  }
+}

--- a/core/src/main/scala/com/hiya/alternator/testkit/LocalDynamoPartial.scala
+++ b/core/src/main/scala/com/hiya/alternator/testkit/LocalDynamoPartial.scala
@@ -4,14 +4,20 @@ import cats.MonadThrow
 import cats.syntax.all._
 import com.hiya.alternator.{DynamoDB, DynamoDBClient}
 
-class LocalDynamoPartial[+R, C <: DynamoDBClient](client: C, tableName: String, magnet: SchemaMagnet, value: R) {
+final case class LocalDynamoPartial[+R, C <: DynamoDBClient](
+  client: C,
+  tableName: String,
+  magnet: SchemaMagnet,
+  value: R
+) {
   def eval[F[_]: MonadThrow, T](f: R => F[T])(implicit DB: DynamoDB.Client[F, C]): F[T] = {
     DB.createTable(
       client,
       tableName,
       magnet.hashKey,
       magnet.rangeKey,
-      attributes = magnet.attributes
+      attributes = magnet.attributes,
+      globalSecondaryIndexes = magnet.globalSecondaryIndexes
     ).flatMap { _ =>
       f(value).attemptTap(_ => DB.dropTable(client, tableName))
     }
@@ -19,6 +25,13 @@ class LocalDynamoPartial[+R, C <: DynamoDBClient](client: C, tableName: String, 
 
   def source[F[_], S[_], T](f: R => S[T])(implicit DB: DynamoDB.Aux[F, S, C]): S[T] =
     DB.bracket[Unit, T](
-      DB.createTable(client, tableName, magnet.hashKey, magnet.rangeKey, attributes = magnet.attributes)
+      DB.createTable(
+        client,
+        tableName,
+        magnet.hashKey,
+        magnet.rangeKey,
+        attributes = magnet.attributes,
+        globalSecondaryIndexes = magnet.globalSecondaryIndexes
+      )
     )(_ => DB.dropTable(client, tableName))(_ => f(value))
 }

--- a/core/src/main/scala/com/hiya/alternator/testkit/SchemaMagnet.scala
+++ b/core/src/main/scala/com/hiya/alternator/testkit/SchemaMagnet.scala
@@ -1,11 +1,35 @@
 package com.hiya.alternator.testkit
 
-import com.hiya.alternator.schema.ScalarType
+import com.hiya.alternator.GlobalSecondaryIndex
+import com.hiya.alternator.schema.{IndexSchema, IndexSchemaWithRange, ScalarType}
 
 abstract class SchemaMagnet {
   def hashKey: String
   def rangeKey: Option[String]
   def attributes: List[(String, ScalarType)]
+  def globalSecondaryIndexes: List[GlobalSecondaryIndex] = Nil
+
+  def withIndex[PK](indexSchema: IndexSchema[_, PK]): SchemaMagnet = {
+    val parent = this
+    val gsi = GlobalSecondaryIndex(indexSchema.indexName, indexSchema.schema.pkField)
+    new SchemaMagnet {
+      override def hashKey: String = parent.hashKey
+      override def rangeKey: Option[String] = parent.rangeKey
+      override def attributes: List[(String, ScalarType)] = (parent.attributes ++ indexSchema.schema.schema).distinct
+      override def globalSecondaryIndexes: List[GlobalSecondaryIndex] = parent.globalSecondaryIndexes :+ gsi
+    }
+  }
+
+  def withIndex[PK, RK](indexSchema: IndexSchemaWithRange[_, PK, RK]): SchemaMagnet = {
+    val parent = this
+    val gsi = GlobalSecondaryIndex(indexSchema.indexName, indexSchema.schema.pkField, Some(indexSchema.schema.rkField))
+    new SchemaMagnet {
+      override def hashKey: String = parent.hashKey
+      override def rangeKey: Option[String] = parent.rangeKey
+      override def attributes: List[(String, ScalarType)] = (parent.attributes ++ indexSchema.schema.schema).distinct
+      override def globalSecondaryIndexes: List[GlobalSecondaryIndex] = parent.globalSecondaryIndexes :+ gsi
+    }
+  }
 }
 
 object SchemaMagnet {


### PR DESCRIPTION
A DynamoDB index can have either a partition key or a partition key and a sort key, like a table, but it's not unique. For operations, they support scanning and querying. This means we need to support querying for indexes that have only a partition key, since it doesn't have a GetItem operation.

The API looks like this, see the test for details:
```scala
val schema = TableSchema.schemaWithPK[ExampleData, String]("pk", _.pk)
val indexSchema = IndexSchema.onTable(schema)("myindex", "intValue", _.intValue)
val table = Table.tableWithPK[ExampleData](tableName).withClient[C](client)
val index = table.index(indexSchema)
DB.queryPK(index, 1)
```