### PR TITLE
fix: correct IllegalDistriminator typo to IllegalDiscriminator

### DIFF
--- a/core/src/main/scala-2/com/hiya/alternator/generic/format/CaseObjectDynamoFormat.scala
+++ b/core/src/main/scala-2/com/hiya/alternator/generic/format/CaseObjectDynamoFormat.scala
@@ -1,6 +1,6 @@
 package com.hiya.alternator.generic.format
 
-import com.hiya.alternator.schema.DynamoAttributeError.IllegalDistriminator
+import com.hiya.alternator.schema.DynamoAttributeError.IllegalDiscriminator
 import com.hiya.alternator.schema.DynamoFormat
 import shapeless.{HNil, LabelledGeneric}
 
@@ -13,7 +13,7 @@ object CaseObjectDynamoFormat {
     override def format(name: String): DynamoFormat[A] = {
       DynamoFormat.stringDynamoValue.emap[A](
         x => {
-          if (name == x) Right(gen.from(HNil)) else Left(IllegalDistriminator)
+          if (name == x) Right(gen.from(HNil)) else Left(IllegalDiscriminator)
         },
         { _ =>
           name

--- a/core/src/main/scala-3/com/hiya/alternator/generic/format/DerivedDynamoFormat.scala
+++ b/core/src/main/scala-3/com/hiya/alternator/generic/format/DerivedDynamoFormat.scala
@@ -68,7 +68,7 @@ object DerivedDynamoFormat:
     def read[AV: AttributeValue](label: String, av: AV): Result[A] =
       summon[AttributeValue[AV]].string(av) match
         case Some(`label`) => Right(singleton)
-        case _ => Left(DynamoAttributeError.IllegalDistriminator)
+        case _ => Left(DynamoAttributeError.IllegalDiscriminator)
 
   /** Case class variant: delegates to `RootDynamoFormat` for the variant type. */
   final class CaseClassDef[A](fmt: RootDynamoFormat[A]) extends VariantDef[A]:
@@ -135,4 +135,4 @@ object DerivedDynamoFormat:
             case (label, variant) if av.containsKey(label) =>
               variant.read[AV](label, av.get(label))
           }
-          .getOrElse(Left(DynamoAttributeError.IllegalDistriminator))
+          .getOrElse(Left(DynamoAttributeError.IllegalDiscriminator))

--- a/core/src/main/scala/com/hiya/alternator/schema/DynamoAttributeError.scala
+++ b/core/src/main/scala/com/hiya/alternator/schema/DynamoAttributeError.scala
@@ -31,7 +31,7 @@ object DynamoAttributeError {
     override def message: String = "should not be null"
   }
 
-  final case object IllegalDistriminator extends FormatError {
+  final case object IllegalDiscriminator extends FormatError {
     override def message: String = "Cannot find valid discriminator"
   }
 }

--- a/core/src/test/scala/com/hiya/alternator/GenericRoundtripSpec.scala
+++ b/core/src/test/scala/com/hiya/alternator/GenericRoundtripSpec.scala
@@ -156,7 +156,7 @@ class GenericRoundtripSpec extends AnyFunSpec with Matchers {
             val AV = implicitly[com.hiya.alternator.schema.AttributeValue[AV]]
             AV.string(av.getOrDefault("v", AV.nullValue))
               .map(s => Right(WithValue(s.toLowerCase)))
-              .getOrElse(Left(com.hiya.alternator.schema.DynamoAttributeError.IllegalDistriminator))
+              .getOrElse(Left(com.hiya.alternator.schema.DynamoAttributeError.IllegalDiscriminator))
           }
         }
 


### PR DESCRIPTION
Fixes a typo in the error case object name and all its usage sites — `IllegalDistriminator` → `IllegalDiscriminator`.

- `DynamoAttributeError.scala`: rename the case object
- `CaseObjectDynamoFormat.scala` (Scala 2): update import and usage
- `DerivedDynamoFormat.scala` (Scala 3): update 2 usages
- `GenericRoundtripSpec.scala`: update test reference

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Ragnarsson