### PR TITLE
Add type-safe field[V] condition DSL alongside attr()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .bsp
 dynamodb-local
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ object PekkoExample extends App {
 
 - **Type-safe schemas**: Define table structure with compile-time guarantees using `TableSchema`
 - **Automatic serialization**: Derive `DynamoFormat` for case classes with Shapeless-based generic derivation
-- **Conditional operations**: Type-safe condition expressions for put and delete operations
+- **Conditional operations**: Condition expressions for put and delete operations, built with either the untyped `attr(...)` escape hatch (e.g. `attr[Int]("age") > 18`) or the compile-time-checked `field[V](_.selector)` DSL (e.g. `field[User](_.age) > 18`), which only accepts conditions valid for `User`
 - **Batch operations**: Efficient batch reads and writes with automatic batching
 - **Secondary indexes**: Query and scan operations with Global and Local Secondary Index support
 - **Streaming**: Memory-efficient streaming with fs2 (Cats Effect) or Akka Streams

--- a/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
+++ b/akka-aws1/src/main/scala/com/hiya/alternator/akka/AkkaAws1.scala
@@ -50,7 +50,7 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
   override def scan[V, PK](
     table: TableLike[Aws1DynamoDBClient, V, PK],
     segment: Option[Segment],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -91,7 +91,7 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
     table: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client]
@@ -108,7 +108,7 @@ class AkkaAws1 private (override implicit val system: ActorSystem, override impl
   override def queryPK[V, PK](
     table: Index[Aws1DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Aws1DynamoDBClient]

--- a/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
+++ b/akka-aws2/src/main/scala/com/hiya/alternator/akka/AkkaAws2.scala
@@ -53,7 +53,7 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
   override def scan[V, PK](
     table: TableLike[Aws2DynamoDBClient, V, PK],
     segment: Option[Segment],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -94,7 +94,7 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
     table: TableWithRangeLike[Aws2DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -112,7 +112,7 @@ class AkkaAws2 private (override implicit val system: ActorSystem, override impl
   override def queryPK[V, PK](
     table: Index[Aws2DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Aws2DynamoDBClient]

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1IndexOps.scala
@@ -15,7 +15,7 @@ class Aws1IndexOps[V, PK](val underlying: Index[Aws1DynamoDBClient, V, PK]) exte
 
   def queryPK(
     pk: PK,
-    condition: Option[ConditionExpression[_]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean,
     overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
   ): model.QueryRequest = {

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableLikeOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableLikeOps.scala
@@ -19,7 +19,7 @@ final class Aws1TableLikeOps[V, PK](val underlying: TableLike[_, V, PK]) {
 
   final def scan(
     segment: Option[Segment] = None,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean,
     overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
   ): ScanRequest = {
@@ -31,7 +31,7 @@ final class Aws1TableLikeOps[V, PK](val underlying: TableLike[_, V, PK]) {
         }
       )(segment)
       .withConsistentRead(consistent)
-      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+      .optApp[ConditionExpression[V, Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
 
     overrides(request).asInstanceOf[ScanRequest]
   }

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableOps.scala
@@ -120,26 +120,26 @@ final class Aws1TableOps[V, PK](val underlying: com.hiya.alternator.Table[_, V, 
 
   final def put(
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     returnOld: Boolean,
     overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
   ): PutItemRequest = {
     val req = new PutItemRequest(underlying.tableName, underlying.schema.serializeValue.writeFields(item))
       .withReturnValues(if (returnOld) ReturnValue.ALL_OLD else ReturnValue.NONE)
-      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+      .optApp[ConditionExpression[V, Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
 
     overrides(req).asInstanceOf[PutItemRequest]
   }
 
   final def delete(
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     returnOld: Boolean,
     overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
   ): DeleteItemRequest = {
     val req = new DeleteItemRequest(underlying.tableName, underlying.schema.serializePK(key))
       .withReturnValues(if (returnOld) ReturnValue.ALL_OLD else ReturnValue.NONE)
-      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+      .optApp[ConditionExpression[V, Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
 
     overrides(req).asInstanceOf[DeleteItemRequest]
   }

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableWithRangeLikeOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableWithRangeLikeOps.scala
@@ -17,7 +17,7 @@ class Aws1TableWithRangeLikeOps[V, PK, RK](val underlying: TableWithRangeLike[Aw
   def query(
     pk: PK,
     rk: RKCondition[RK] = RKCondition.Empty,
-    condition: Option[ConditionExpression[_]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean,
     overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
   ): model.QueryRequest = {

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
@@ -53,7 +53,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override def doPut[V, PK](
     table: Table[Aws1DynamoDBClient, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
@@ -72,7 +72,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override def doPutAndReturn[V, PK](
     table: Table[Aws1DynamoDBClient, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
@@ -90,7 +90,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override def doDelete[V, PK](
     table: Table[Aws1DynamoDBClient, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
@@ -108,7 +108,7 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override def doDeleteAndReturn[V, PK](
     table: Table[Aws1DynamoDBClient, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2IndexOps.scala
@@ -17,7 +17,7 @@ class Aws2IndexOps[V, PK](val underlying: Aws2Index[V, PK]) extends AnyVal {
 
   def query(
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean = false,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): model.QueryRequest.Builder = {

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableLikeOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableLikeOps.scala
@@ -23,7 +23,7 @@ class Aws2TableLikeOps[V, PK](val underlying: TableLike[Aws2DynamoDBClient, V, P
 
   final def scan(
     segment: Option[Segment] = None,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): ScanRequest.Builder = {

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
@@ -131,7 +131,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
 
   final def put(
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     returnOld: Boolean,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): PutItemRequest.Builder = {
@@ -139,7 +139,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
       .builder()
       .item(schema.serializeValue.writeFields(item))
       .tableName(tableName)
-      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+      .optApp[ConditionExpression[V, Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
       .returnValues(if (returnOld) ReturnValue.ALL_OLD else ReturnValue.NONE)
       .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
   }
@@ -154,7 +154,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
 
   final def delete(
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     returnOld: Boolean = false,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): DeleteItemRequest.Builder = {
@@ -162,7 +162,7 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
       .builder()
       .key(schema.serializePK(key))
       .tableName(tableName)
-      .optApp[ConditionExpression[Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
+      .optApp[ConditionExpression[V, Boolean]](req => cond => ConditionalSupport.eval(req, cond))(condition)
       .returnValues(if (returnOld) ReturnValue.ALL_OLD else ReturnValue.NONE)
       .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
   }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableWithRangeLikeOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableWithRangeLikeOps.scala
@@ -18,7 +18,7 @@ class Aws2TableWithRangeLikeOps[V, PK, RK](val underlying: Aws2TableWithRangeLik
   def query(
     pk: PK,
     rk: RKCondition[RK] = RKCondition.Empty,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     consistent: Boolean = false,
     overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
   ): model.QueryRequest.Builder = {

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
@@ -48,14 +48,14 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override protected def doPut[V, PK](
     table: Table[Aws2DynamoDBClient, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     val req = Aws2TableOps(table).put(item, condition, returnOld = false, overrides = resolvedOverride).build()
     async(table.client.client.putItem(req))
       .map(_ => true)
-      .optApp[ConditionExpression[Boolean]](f =>
+      .optApp[ConditionExpression[V, Boolean]](f =>
         _ => f.recover { case _: model.ConditionalCheckFailedException => false }
       )(condition)
   }
@@ -63,7 +63,7 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override protected def doPutAndReturn[V, PK](
     table: Table[Aws2DynamoDBClient, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
@@ -78,17 +78,17 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override protected def doDelete[V, PK](
     table: Table[Aws2DynamoDBClient, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)
     val req = Aws2TableOps(table).delete(key, condition, returnOld = false, resolvedOverride).build()
     async(table.client.client.deleteItem(req))
       .map(_ => true)
-      .optApp[ConditionExpression[Boolean]](f =>
+      .optApp[ConditionExpression[V, Boolean]](f =>
         _ => f.recoverWith { case ex: CompletionException => MonadThrow[F].raiseError(ex.getCause) }
       )(condition)
-      .optApp[ConditionExpression[Boolean]](f =>
+      .optApp[ConditionExpression[V, Boolean]](f =>
         _ => f.recover { case _: model.ConditionalCheckFailedException => false }
       )(condition)
   }
@@ -96,7 +96,7 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
   override protected def doDeleteAndReturn[V, PK](
     table: Table[Aws2DynamoDBClient, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]] = {
     val resolvedOverride = (table.overrides |+| overrides)(table.client)

--- a/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
+++ b/cats-aws1/src/main/scala/com/hiya/alternator/cats/CatsAws1.scala
@@ -53,7 +53,7 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
   override def scan[V, PK](
     table: TableLike[Aws1DynamoDBClient, V, PK],
     segment: Option[Segment],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -92,7 +92,7 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
     table: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -109,7 +109,7 @@ class CatsAws1[F[+_]](protected override implicit val F: Async[F])
   override def queryPK[V, PK](
     table: Index[Aws1DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client]

--- a/cats-aws2/src/main/scala/com/hiya/alternator/cats/CatsAws2.scala
+++ b/cats-aws2/src/main/scala/com/hiya/alternator/cats/CatsAws2.scala
@@ -45,7 +45,7 @@ class CatsAws2[F[+_]](protected override implicit val F: Async[F])
   override def scan[V, PK](
     table: TableLike[Aws2DynamoDBClient, V, PK],
     segment: Option[Segment] = None,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client]
@@ -85,7 +85,7 @@ class CatsAws2[F[+_]](protected override implicit val F: Async[F])
     table: TableWithRangeLike[Aws2DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK] = RKCondition.Empty,
-    condition: Option[ConditionExpression[Boolean]] = None,
+    condition: Option[ConditionExpression[V, Boolean]] = None,
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -101,7 +101,7 @@ class CatsAws2[F[+_]](protected override implicit val F: Async[F])
   override def queryPK[V, PK](
     table: Index[Aws2DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Aws2DynamoDBClient]

--- a/core/src/main/scala-2/com/hiya/alternator/generic/util/FieldSelectorMacros.scala
+++ b/core/src/main/scala-2/com/hiya/alternator/generic/util/FieldSelectorMacros.scala
@@ -1,0 +1,49 @@
+package com.hiya.alternator.generic.util
+
+import com.hiya.alternator.syntax.ConditionExpression
+
+import scala.reflect.macros.blackbox
+
+class FieldSelectorMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  def field[V: c.WeakTypeTag, F: c.WeakTypeTag](selector: c.Expr[V => F]): c.Expr[ConditionExpression.Path[V, F]] = {
+
+    // Each Select node is already fully typechecked by the time the macro runs (selector's
+    // static type is V => F), so `tree.tpe` gives the real, precise type of that field —
+    // no need to fall back to Any and cast at the end.
+    def segments(tree: Tree): List[(String, Type)] = tree match {
+      case Select(inner, name) => segments(inner) :+ ((name.decodedName.toString, tree.tpe.widen))
+      case Ident(_) => Nil
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"field(...) requires a plain field-accessor chain, e.g. field[${weakTypeOf[V]}](_.a.b). Got: ${showRaw(selector.tree)}"
+        )
+    }
+
+    val path = selector.tree match {
+      case Function(List(_), body) => segments(body)
+      case _ =>
+        c.abort(c.enclosingPosition, s"field(...) requires a lambda literal, e.g. field[${weakTypeOf[V]}](_.a.b).")
+    }
+
+    if (path.isEmpty) {
+      c.abort(c.enclosingPosition, "field(...) requires at least one field access, e.g. field[V](_.a).")
+    }
+
+    // No explicit field-existence check needed: `selector.tree` only reaches this point already
+    // typechecked as V => F, so every segment (head and nested) is already a real, accessible
+    // member of its receiver — the ordinary Scala typer rejects `_.nonexistent` before macro
+    // expansion even begins.
+    val vTpe = weakTypeOf[V]
+    val (headName, headTpe) = path.head
+
+    val base: Tree = q"_root_.com.hiya.alternator.syntax.ConditionExpression.Attr[$vTpe, $headTpe]($headName)"
+    val fullTree = path.tail.foldLeft(base) { case (acc, (segment, segTpe)) =>
+      q"$acc.get[$segTpe]($segment)"
+    }
+
+    c.Expr[ConditionExpression.Path[V, F]](fullTree)
+  }
+}

--- a/core/src/main/scala-2/com/hiya/alternator/syntax/FieldSelector.scala
+++ b/core/src/main/scala-2/com/hiya/alternator/syntax/FieldSelector.scala
@@ -1,0 +1,6 @@
+package com.hiya.alternator.syntax
+
+final class FieldSelector[V] {
+  def apply[F](selector: V => F): ConditionExpression.Path[V, F] =
+    macro com.hiya.alternator.generic.util.FieldSelectorMacros.field[V, F]
+}

--- a/core/src/main/scala-3/com/hiya/alternator/generic/util/FieldSelectorMacros.scala
+++ b/core/src/main/scala-3/com/hiya/alternator/generic/util/FieldSelectorMacros.scala
@@ -1,0 +1,69 @@
+package com.hiya.alternator.generic.util
+
+import com.hiya.alternator.syntax.ConditionExpression
+
+import scala.quoted.*
+
+object FieldSelectorMacros {
+
+  def field[V: Type, F: Type](selector: Expr[V => F])(using Quotes): Expr[ConditionExpression.Path[V, F]] = {
+    import quotes.reflect.*
+
+    // Each Term is already fully typechecked by the time the macro runs (selector's static
+    // type is V => F), so `term.tpe` gives the real, precise type of that field — no need to
+    // fall back to Any and cast at the end.
+    def segments(term: Term): List[(String, TypeRepr)] = term match {
+      case Select(inner, name) => segments(inner) :+ (name, term.tpe.widen)
+      case Ident(_) => Nil
+      case _ =>
+        report.errorAndAbort(
+          s"field(...) requires a plain field-accessor chain, e.g. field[${Type.show[V]}](_.a.b). Got: ${term.show}"
+        )
+    }
+
+    def body(term: Term): Term = term match {
+      case Inlined(_, _, inner) => body(inner)
+      case Block(List(DefDef(_, _, _, Some(b))), _) => b
+      case Lambda(_, b) => b
+      case _ =>
+        report.errorAndAbort(s"field(...) requires a lambda literal, e.g. field[${Type.show[V]}](_.a.b).")
+    }
+
+    // No explicit field-existence check needed: `selector` only reaches this point already
+    // typechecked as V => F, so every segment (head and nested) is already a real, accessible
+    // member of its receiver — the ordinary Dotty typer rejects `_.nonexistent` before macro
+    // expansion even begins.
+    val path = segments(body(selector.asTerm))
+    if (path.isEmpty) {
+      report.errorAndAbort("field(...) requires at least one field access, e.g. field[V](_.a).")
+    }
+
+    // Each segment's real type is only known once its TypeRepr is bound to a fresh type variable
+    // via asType, so the fold has to happen inside that binding, one segment at a time. The final
+    // Cur is, by construction, the same type as F (both come from typechecking the same selector
+    // expression) — asExprOf checks that equality at macro-expansion time; it does not add any
+    // runtime cast to the generated code.
+    def buildFrom[Cur: Type](
+      acc: Expr[ConditionExpression.Path[V, Cur]],
+      remaining: List[(String, TypeRepr)]
+    ): Expr[ConditionExpression.Path[V, F]] =
+      remaining match {
+        case Nil =>
+          acc.asExprOf[ConditionExpression.Path[V, F]]
+        case (segName, segTpe) :: rest =>
+          segTpe.asType match {
+            case '[segT] =>
+              val next: Expr[ConditionExpression.Path[V, segT]] = '{ $acc.get[segT](${ Expr(segName) }) }
+              buildFrom[segT](next, rest)
+          }
+      }
+
+    val (headName, headTpe) = path.head
+    headTpe.asType match {
+      case '[headT] =>
+        val base: Expr[ConditionExpression.Path[V, headT]] =
+          '{ ConditionExpression.Attr[V, headT](${ Expr(headName) }) }
+        buildFrom[headT](base, path.tail)
+    }
+  }
+}

--- a/core/src/main/scala-3/com/hiya/alternator/syntax/FieldSelector.scala
+++ b/core/src/main/scala-3/com/hiya/alternator/syntax/FieldSelector.scala
@@ -1,0 +1,8 @@
+package com.hiya.alternator.syntax
+
+import com.hiya.alternator.generic.util.FieldSelectorMacros
+
+final class FieldSelector[V] {
+  inline def apply[F](inline selector: V => F): ConditionExpression.Path[V, F] =
+    ${ FieldSelectorMacros.field[V, F]('selector) }
+}

--- a/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
+++ b/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
@@ -74,7 +74,7 @@ trait DynamoDBSource {
   def scan[V, PK](
     table: TableLike[Client, V, PK],
     segment: Option[Segment] = None,
-    condition: Option[ConditionExpression[Boolean]] = None,
+    condition: Option[ConditionExpression[V, Boolean]] = None,
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -84,7 +84,7 @@ trait DynamoDBSource {
     table: TableWithRangeLike[Client, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK] = RKCondition.Empty,
-    condition: Option[ConditionExpression[Boolean]] = None,
+    condition: Option[ConditionExpression[V, Boolean]] = None,
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -93,7 +93,7 @@ trait DynamoDBSource {
   def queryPK[V, PK](
     table: Index[Client, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]] = None,
+    condition: Option[ConditionExpression[V, Boolean]] = None,
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -150,7 +150,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def put[V, O](
     table: Table[Client, V, _],
     value: V,
-    condition: ConditionExpression[Boolean]
+    condition: ConditionExpression[V, Boolean]
   ): F[Boolean] =
     doPut(table, value, condition = Some(condition), DynamoDBOverride.empty)
 
@@ -164,7 +164,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def put[V](
     table: Table[Client, V, _],
     value: V,
-    condition: ConditionExpression[Boolean],
+    condition: ConditionExpression[V, Boolean],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] =
     doPut(table, value, condition = Some(condition), overrides)
@@ -172,7 +172,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   protected def doPut[V, PK](
     table: Table[Client, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean]
 
@@ -185,7 +185,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def putAndReturn[V](
     table: Table[Client, V, _],
     value: V,
-    condition: ConditionExpression[Boolean]
+    condition: ConditionExpression[V, Boolean]
   ): F[ConditionResult[V]] =
     doPutAndReturn(table, value, condition = Some(condition), overrides = DynamoDBOverride.empty)
 
@@ -202,7 +202,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def putAndReturn[V](
     table: Table[Client, V, _],
     value: V,
-    condition: ConditionExpression[Boolean],
+    condition: ConditionExpression[V, Boolean],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]] =
     doPutAndReturn(table, value, condition = Some(condition), overrides = overrides)
@@ -210,17 +210,17 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   protected def doPutAndReturn[V, PK](
     table: Table[Client, V, PK],
     item: V,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]]
 
   @inline final def delete[V, PK, T](table: Table[Client, V, PK], key: T)(implicit T: ItemMagnet[T, V, PK]): F[Unit] =
     doDelete(table, T.key(key)(table.schema), None, DynamoDBOverride.empty).map(_ => ())
 
-  @inline final def delete[PK](
-    table: Table[Client, _, PK],
+  @inline final def delete[V, PK](
+    table: Table[Client, V, PK],
     key: PK,
-    condition: ConditionExpression[Boolean]
+    condition: ConditionExpression[V, Boolean]
   ): F[Boolean] =
     doDelete(table, key, Some(condition), DynamoDBOverride.empty)
 
@@ -229,10 +229,10 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   ): F[Unit] =
     doDelete(table, T.key(key)(table.schema), None, overrides).map(_ => ())
 
-  @inline final def delete[PK](
-    table: Table[Client, _, PK],
+  @inline final def delete[V, PK](
+    table: Table[Client, V, PK],
     key: PK,
-    condition: ConditionExpression[Boolean],
+    condition: ConditionExpression[V, Boolean],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean] =
     doDelete(table, key, Some(condition), overrides)
@@ -240,7 +240,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   protected def doDelete[V, PK](
     table: Table[Client, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[Boolean]
 
@@ -255,7 +255,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def deleteAndReturn[T, V, PK](
     table: Table[Client, V, PK],
     key: T,
-    condition: ConditionExpression[Boolean]
+    condition: ConditionExpression[V, Boolean]
   )(implicit T: ItemMagnet[T, V, PK]): F[ConditionResult[V]] =
     doDeleteAndReturn(table, T.key(key)(table.schema), Some(condition), DynamoDBOverride.empty)
 
@@ -274,7 +274,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   @inline final def deleteAndReturn[T, V, PK](
     table: Table[Client, V, PK],
     key: T,
-    condition: ConditionExpression[Boolean],
+    condition: ConditionExpression[V, Boolean],
     overrides: DynamoDBOverride[Client]
   )(implicit T: ItemMagnet[T, V, PK]): F[ConditionResult[V]] =
     doDeleteAndReturn(table, T.key(key)(table.schema), Some(condition), overrides)
@@ -282,7 +282,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
   protected def doDeleteAndReturn[V, PK](
     value: Table[Client, V, PK],
     key: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]]
 

--- a/core/src/main/scala/com/hiya/alternator/internal/ConditionalSupport.scala
+++ b/core/src/main/scala/com/hiya/alternator/internal/ConditionalSupport.scala
@@ -14,7 +14,7 @@ private[alternator] trait ConditionalSupport[Builder, AV] {
 }
 
 private[alternator] object ConditionalSupport {
-  def apply[Builder, AV: AttributeValue](builder: Builder, expression: ConditionExpression[Boolean])(implicit
+  def apply[V, Builder, AV: AttributeValue](builder: Builder, expression: ConditionExpression[V, Boolean])(implicit
     Builder: ConditionalSupport[Builder, AV]
   ): IndexedStateT[Eval, ConditionParameters[AV], ConditionParameters[AV], Builder] =
     for {
@@ -22,7 +22,7 @@ private[alternator] object ConditionalSupport {
       ret <- Condition.execute(Builder.withConditionExpression(builder, exp))
     } yield ret
 
-  def eval[Builder, AV: AttributeValue](builder: Builder, expression: ConditionExpression[Boolean])(implicit
+  def eval[V, Builder, AV: AttributeValue](builder: Builder, expression: ConditionExpression[V, Boolean])(implicit
     Builder: ConditionalSupport[Builder, AV]
   ): Builder =
     Condition.eval(apply(builder, expression))

--- a/core/src/main/scala/com/hiya/alternator/internal/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/internal/package.scala
@@ -30,7 +30,7 @@ package object internal {
         (params.copy(attributeValues = params.attributeValues.updated(value, idx)), idx)
       }
 
-    def renderCondition[AV: AttributeValue](expression: ConditionExpression[_]): Condition[AV, String] =
+    def renderCondition[AV: AttributeValue](expression: ConditionExpression[_, _]): Condition[AV, String] =
       expression match {
         case Attr(name) =>
           getParam(name)

--- a/core/src/main/scala/com/hiya/alternator/syntax/ConditionExpression.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/ConditionExpression.scala
@@ -2,68 +2,68 @@ package com.hiya.alternator.syntax
 
 import com.hiya.alternator.schema.{AttributeValue, ScalarDynamoFormat}
 
-sealed trait ConditionExpression[+T]
+sealed trait ConditionExpression[-V, +T]
 
 object ConditionExpression {
 
-  final class ConditionExpressionBoolExt(val expr: ConditionExpression[Boolean]) extends AnyVal {
+  final class ConditionExpressionBoolExt[V](val expr: ConditionExpression[V, Boolean]) extends AnyVal {
 
-    def &&(rhs: ConditionExpression[Boolean]): ConditionExpression[Boolean] =
+    def &&(rhs: ConditionExpression[V, Boolean]): ConditionExpression[V, Boolean] =
       ConditionExpression.BinOp("AND", expr, rhs)
 
-    def ||(rhs: ConditionExpression[Boolean]): ConditionExpression[Boolean] =
+    def ||(rhs: ConditionExpression[V, Boolean]): ConditionExpression[V, Boolean] =
       ConditionExpression.BinOp("OR", expr, rhs)
 
-    def unary_! : ConditionExpression[Boolean] =
+    def unary_! : ConditionExpression[V, Boolean] =
       ConditionExpression.FunCall("NOT", List(expr))
   }
 
-  sealed trait Path[T] extends ConditionExpression[T] {
+  sealed trait Path[V, T] extends ConditionExpression[V, T] {
 
-    def get[U](index: Long): Path[U] = ArrayIndex[U](this, index)
-    def get[U](fieldName: String): Path[U] = MapIndex[U](this, fieldName)
+    def get[U](index: Long): Path[V, U] = ArrayIndex[V, U](this, index)
+    def get[U](fieldName: String): Path[V, U] = MapIndex[V, U](this, fieldName)
 
-    def exists: FunCall[Boolean] = FunCall("attribute_exists", List(this))
-    def notExists: FunCall[Boolean] = FunCall("attribute_not_exists", List(this))
+    def exists: FunCall[V, Boolean] = FunCall("attribute_exists", List(this))
+    def notExists: FunCall[V, Boolean] = FunCall("attribute_not_exists", List(this))
 
-    def ===[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp("=", this, ev.expr(rhs))
-    def =!=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp("<>", this, ev.expr(rhs))
-    def <[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp("<", this, ev.expr(rhs))
-    def >[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp(">", this, ev.expr(rhs))
-    def <=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp("<=", this, ev.expr(rhs))
-    def >=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, T]): BinOp[Boolean] = BinOp(">=", this, ev.expr(rhs))
+    def ===[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp("=", this, ev.expr(rhs))
+    def =!=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp("<>", this, ev.expr(rhs))
+    def <[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp("<", this, ev.expr(rhs))
+    def >[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp(">", this, ev.expr(rhs))
+    def <=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp("<=", this, ev.expr(rhs))
+    def >=[Rhs](rhs: Rhs)(implicit ev: ExprLike[Rhs, V, T]): BinOp[V, Boolean] = BinOp(">=", this, ev.expr(rhs))
   }
 
-  trait ExprLike[-From, +To] {
-    def expr(from: From): ConditionExpression[To]
+  trait ExprLike[-From, V, +To] {
+    def expr(from: From): ConditionExpression[V, To]
   }
 
   object ExprLike {
-    implicit def conditionExpressionIsExprLike[T]: ExprLike[ConditionExpression[T], T] =
-      (from: ConditionExpression[T]) => from
+    implicit def conditionExpressionIsExprLike[V, T]: ExprLike[ConditionExpression[V, T], V, T] =
+      (from: ConditionExpression[V, T]) => from
 
-    implicit def scalarDynamoFormatIsExprLike[T: ScalarDynamoFormat]: ExprLike[T, T] =
+    implicit def scalarDynamoFormatIsExprLike[V, T: ScalarDynamoFormat]: ExprLike[T, V, T] =
       (from: T) => Literal(from)
   }
 
-  private[alternator] final case class Attr[T](
+  private[alternator] final case class Attr[V, T](
     name: String
-  ) extends Path[T]
+  ) extends Path[V, T]
 
-  private[alternator] final case class ArrayIndex[T](
-    base: Path[_],
+  private[alternator] final case class ArrayIndex[V, T](
+    base: Path[V, _],
     index: Long
-  ) extends Path[T]
+  ) extends Path[V, T]
 
-  private[alternator] final case class MapIndex[T](
-    base: Path[_],
+  private[alternator] final case class MapIndex[V, T](
+    base: Path[V, _],
     fieldName: String
-  ) extends Path[T]
+  ) extends Path[V, T]
 
   private[alternator] final case class Literal[T](
     value: T
   )(implicit format: ScalarDynamoFormat[T])
-    extends ConditionExpression[T] {
+    extends ConditionExpression[Any, T] {
     def write[AV: AttributeValue]: AV = format.write[AV](value)
   }
 
@@ -71,15 +71,15 @@ object ConditionExpression {
     def apply[T: ScalarDynamoFormat](t: T): Literal[T] = new Literal(t)
   }
 
-  private[alternator] final case class FunCall[T](
+  private[alternator] final case class FunCall[V, T](
     name: String,
-    args: List[ConditionExpression[_]]
-  ) extends ConditionExpression[T]
+    args: List[ConditionExpression[V, _]]
+  ) extends ConditionExpression[V, T]
 
-  private[alternator] final case class BinOp[T](
+  private[alternator] final case class BinOp[V, T](
     op: String,
-    lhs: ConditionExpression[_],
-    rhs: ConditionExpression[_]
-  ) extends ConditionExpression[T]
+    lhs: ConditionExpression[V, _],
+    rhs: ConditionExpression[V, _]
+  ) extends ConditionExpression[V, T]
 
 }

--- a/core/src/main/scala/com/hiya/alternator/syntax/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/package.scala
@@ -25,12 +25,22 @@ package object syntax {
     def between[T: ScalarDynamoFormat](lower: T, upper: T): RKCondition.BETWEEN[T] = RKCondition.BETWEEN(lower, upper)
   }
 
-  def attr[T](name: String): ConditionExpression.Path[T] = ConditionExpression.Attr(name)
-  def lit[T: ScalarDynamoFormat](literal: T): ConditionExpression[T] = ConditionExpression.Literal(literal)
+  /** Builds an untyped attribute-path condition from a raw field name. Always usable against any table, since the
+    * result is not tied to any specific item type — prefer [[field]] where the field is a real member of the item's
+    * case class; use `attr` for dynamic field names or attributes not modeled as case class fields.
+    */
+  def attr[T](name: String): ConditionExpression.Path[Any, T] = ConditionExpression.Attr(name)
+  def lit[T: ScalarDynamoFormat](literal: T): ConditionExpression[Any, T] = ConditionExpression.Literal(literal)
 
-  implicit def toConditionExpressionBoolExt(
-    expr: ConditionExpression[Boolean]
-  ): ConditionExpression.ConditionExpressionBoolExt =
-    new ConditionExpression.ConditionExpressionBoolExt(expr)
+  /** Builds a compile-time-checked attribute-path condition from a field-accessor selector, e.g.
+    * `field[Person](_.address.city)`. The selector must be a plain accessor chain — arbitrary expressions inside the
+    * lambda are a compile error. Unlike [[attr]], the resulting condition can only be used against operations on `V`.
+    */
+  def field[V]: FieldSelector[V] = new FieldSelector[V]
+
+  implicit def toConditionExpressionBoolExt[V](
+    expr: ConditionExpression[V, Boolean]
+  ): ConditionExpression.ConditionExpressionBoolExt[V] =
+    new ConditionExpression.ConditionExpressionBoolExt[V](expr)
 
 }

--- a/core/src/test/scala/com/hiya/alternator/ConditionExpressionTestBase.scala
+++ b/core/src/test/scala/com/hiya/alternator/ConditionExpressionTestBase.scala
@@ -13,7 +13,7 @@ object ConditionExpressionTestBase {
 abstract class ConditionExpressionTestBase[AV](implicit av: AttributeValue[AV]) extends AnyFunSpec with Matchers {
   import ConditionExpressionTestBase._
 
-  def render(expression: ConditionExpression[Boolean]): RenderedConditional[AV] = {
+  def render(expression: ConditionExpression[Any, Boolean]): RenderedConditional[AV] = {
     val (params, exp) = Condition.renderCondition(expression).run(ConditionParameters.empty).value
     RenderedConditional(exp, params.names, params.values)
   }

--- a/core/src/test/scala/com/hiya/alternator/syntax/CrossTypeConditionSpec.scala
+++ b/core/src/test/scala/com/hiya/alternator/syntax/CrossTypeConditionSpec.scala
@@ -1,0 +1,36 @@
+package com.hiya.alternator.syntax
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.annotation.unused
+
+class CrossTypeConditionSpec extends AnyFunSpec with Matchers {
+  case class Foo(value: Int)
+  case class Bar(value: Int)
+
+  // Mirrors the shape of DynamoDB.scala's `condition: ConditionExpression[V, Boolean]`
+  // parameter without depending on any concrete DynamoDB client/effect module.
+  // The parameter is intentionally unused: this method exists only to be
+  // typechecked at each call site below, never actually invoked at runtime.
+  def useCondition[V](@unused condition: ConditionExpression[V, Boolean]): Boolean = true
+
+  describe("field[V] conditions") {
+    it("should not compile when used where a different V is expected") {
+      assertDoesNotCompile("""useCondition[Bar](field[Foo](_.value) === 1)""")
+    }
+
+    it("should compile when used against the matching V") {
+      assertCompiles("""useCondition[Foo](field[Foo](_.value) === 1)""")
+    }
+
+    it("should fail to compile on a type-mismatched comparison") {
+      assertDoesNotCompile("""field[Foo](_.value) === "not an int"""")
+    }
+
+    it("should still accept attr(...) as an untyped escape hatch for any V") {
+      assertCompiles("""useCondition[Foo](attr("value") === 1)""")
+      assertCompiles("""useCondition[Bar](attr("value") === 1)""")
+    }
+  }
+}

--- a/core/src/test/scala/com/hiya/alternator/syntax/FieldSelectorSpec.scala
+++ b/core/src/test/scala/com/hiya/alternator/syntax/FieldSelectorSpec.scala
@@ -1,0 +1,28 @@
+package com.hiya.alternator.syntax
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class FieldSelectorSpec extends AnyFunSpec with Matchers {
+  case class Sample(key: String, value: Int)
+
+  describe("field") {
+    it("should build the same Attr as attr() for a top-level field") {
+      val viaField = field[Sample](_.value)
+      viaField shouldBe ConditionExpression.Attr[Sample, Int]("value")
+    }
+
+    it("should produce a working condition via ===") {
+      val cond = field[Sample](_.value) === 1000
+      cond shouldBe ConditionExpression.BinOp[Sample, Boolean](
+        "=",
+        ConditionExpression.Attr[Sample, Int]("value"),
+        ConditionExpression.Literal(1000)
+      )
+    }
+
+    it("should fail to compile for a nonexistent field") {
+      assertDoesNotCompile("""field[Sample](_.nonexistent)""")
+    }
+  }
+}

--- a/core/src/test/scala/com/hiya/alternator/syntax/NestedFieldSelectorSpec.scala
+++ b/core/src/test/scala/com/hiya/alternator/syntax/NestedFieldSelectorSpec.scala
@@ -1,0 +1,31 @@
+package com.hiya.alternator.syntax
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class NestedFieldSelectorSpec extends AnyFunSpec with Matchers {
+  case class Zip(code: String)
+  case class Address(city: String, zip: Zip)
+  case class Person(name: String, address: Address)
+
+  describe("field with a nested selector") {
+    it("should build a MapIndex wrapping an Attr") {
+      val path = field[Person](_.address.city)
+      path shouldBe ConditionExpression.MapIndex[Person, String](
+        ConditionExpression.Attr[Person, Address]("address"),
+        "city"
+      )
+    }
+
+    it("should build a MapIndex chain for a three-segment selector") {
+      val path = field[Person](_.address.zip.code)
+      path shouldBe ConditionExpression.MapIndex[Person, String](
+        ConditionExpression.MapIndex[Person, Zip](
+          ConditionExpression.Attr[Person, Address]("address"),
+          "zip"
+        ),
+        "code"
+      )
+    }
+  }
+}

--- a/integration-tests/base/src/main/scala/com/hiya/alternator/DynamoDBTestBase.scala
+++ b/integration-tests/base/src/main/scala/com/hiya/alternator/DynamoDBTestBase.scala
@@ -6,7 +6,7 @@ import com.hiya.alternator.generic.semiauto
 import com.hiya.alternator.schema.{IndexSchema, IndexSchemaWithRange, RootDynamoFormat, TableSchema}
 import com.hiya.alternator.syntax._
 import com.hiya.alternator.testkit.{LocalDynamoDB, TestContainerInitializer}
-import com.hiya.alternator.util.{DataPK, DataRK}
+import com.hiya.alternator.util.{DataNested, DataPK, DataRK}
 import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatest.matchers.should
 
@@ -173,6 +173,13 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
       result shouldBe List(DataRK("13", "1", "13/1"))
     }
 
+    it("should filter with non-key and range condition using field[V]") {
+      val result = withRangeData(13) { table =>
+        DB.query(table, pk = "13", rk < "5", condition = Some(field[DataRK](_.value) === "13/1")).raiseError
+      }
+      result shouldBe List(DataRK("13", "1", "13/1"))
+    }
+
     it("should filter with non-key condition") {
       val result = withRangeData(13) { table =>
         DB.query(table, pk = "13", condition = Some(attr("value") === "13/1")).raiseError
@@ -209,6 +216,16 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
           DB.put(table, DataPK("new", 1000), attr("key").notExists).map(_ shouldBe true) >>
             DB.put(table, DataPK("new", 1001), attr("value") === 1000).map(_ shouldBe true) >>
             DB.put(table, DataPK("new", 1001), attr("value") === 1000).map(_ shouldBe false)
+        }
+      }
+    }
+
+    it("should work for optimistic locking using field[V]") {
+      eval {
+        DataPK.config.withTable(client).eval { table =>
+          DB.put(table, DataPK("new", 1000), field[DataPK](_.key).notExists).map(_ shouldBe true) >>
+            DB.put(table, DataPK("new", 1001), field[DataPK](_.value) === 1000).map(_ shouldBe true) >>
+            DB.put(table, DataPK("new", 1001), field[DataPK](_.value) === 1000).map(_ shouldBe false)
         }
       }
     }
@@ -272,6 +289,19 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
               table,
               DataPK("complex", 200),
               (attr("value") === 100) && (attr("key") === "complex")
+            ).map(_ shouldBe ConditionResult.Success(Some(Right(DataPK("complex", 100)))))
+        }
+      }
+    }
+
+    it("should handle complex AND conditions that match using field[V]") {
+      eval {
+        DataPK.config.withTable(client).eval { table =>
+          DB.put(table, DataPK("complex", 100)) >>
+            DB.putAndReturn(
+              table,
+              DataPK("complex", 200),
+              (field[DataPK](_.value) === 100) && (field[DataPK](_.key) === "complex")
             ).map(_ shouldBe ConditionResult.Success(Some(Right(DataPK("complex", 100)))))
         }
       }
@@ -452,6 +482,18 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
             // ConditionResult return: condition succeeds -> ConditionResult.Success with old value
             condSuccess <- DB.putAndReturn(table, DataPK("ret-type", 50), attr("value") === 40)
           } yield condSuccess shouldBe ConditionResult.Success(Some(Right(DataPK("ret-type", 40))))
+        }
+      }
+    }
+
+    it("should filter on a nested field using field[V]") {
+      eval {
+        DataNested.config.withTable(client).eval { table =>
+          val row = DataNested("n1", DataNested.Address("Copenhagen", "1000"))
+          DB.put(table, row, field[DataNested](_.key).notExists) >>
+            DB.get(table, "n1").raiseError.map(_ shouldBe Some(row)) >>
+            DB.put(table, row, field[DataNested](_.address.city) === "Copenhagen").map(_ shouldBe true) >>
+            DB.put(table, row, field[DataNested](_.address.city) === "Aarhus").map(_ shouldBe false)
         }
       }
     }

--- a/integration-tests/base/src/main/scala/com/hiya/alternator/util/DataNested.scala
+++ b/integration-tests/base/src/main/scala/com/hiya/alternator/util/DataNested.scala
@@ -1,0 +1,32 @@
+package com.hiya.alternator.util
+
+import com.hiya.alternator.schema.TableSchema
+import com.hiya.alternator.testkit.{LocalDynamoDB, LocalDynamoPartial}
+import com.hiya.alternator.{DynamoDBClient, Table}
+
+case class DataNested(key: String, address: DataNested.Address)
+
+object DataNested {
+  case class Address(city: String, zip: String)
+
+  import com.hiya.alternator.generic.auto._
+
+  type T[C <: DynamoDBClient] = Table[C, DataNested, String]
+
+  implicit val tableSchemaWithPK: TableSchema.Aux[DataNested, String] =
+    TableSchema.schemaWithPK[DataNested, String]("key", _.key)
+
+  implicit val config: TableConfig[DataNested, String, T] =
+    new TableConfig[DataNested, String, T] {
+      override def table[C <: DynamoDBClient](name: String, client: C): Table[C, DataNested, String] =
+        Table.tableWithPK[DataNested](name).withClient(client)
+
+      override def createData(i: Int, v: Option[Int]): (String, DataNested) =
+        i.toString -> DataNested(i.toString, Address(s"city-$i", s"zip-${v.getOrElse(i)}"))
+
+      override def withTable[F[_], S[_], C <: DynamoDBClient](
+        client: C
+      ): LocalDynamoPartial[Table[C, DataNested, String], C] =
+        LocalDynamoDB.withRandomTable[C, DataNested](client)
+    }
+}

--- a/pekko-aws1/src/main/scala/com/hiya/alternator/pekko/PekkoAws1.scala
+++ b/pekko-aws1/src/main/scala/com/hiya/alternator/pekko/PekkoAws1.scala
@@ -51,7 +51,7 @@ class PekkoAws1 private (override implicit val system: ActorSystem, override imp
   override def scan[V, PK](
     table: TableLike[Aws1DynamoDBClient, V, PK],
     segment: Option[Segment],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -93,7 +93,7 @@ class PekkoAws1 private (override implicit val system: ActorSystem, override imp
     table: TableWithRangeLike[Aws1DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Client]
@@ -110,7 +110,7 @@ class PekkoAws1 private (override implicit val system: ActorSystem, override imp
   override def queryPK[V, PK](
     table: Index[Aws1DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Aws1DynamoDBClient]

--- a/pekko-aws2/src/main/scala/com/hiya/alternator/pekko/PekkoAws2.scala
+++ b/pekko-aws2/src/main/scala/com/hiya/alternator/pekko/PekkoAws2.scala
@@ -53,7 +53,7 @@ class PekkoAws2 private (override implicit val system: ActorSystem, override imp
   override def scan[V, PK](
     table: TableLike[Aws2DynamoDBClient, V, PK],
     segment: Option[Segment],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -94,7 +94,7 @@ class PekkoAws2 private (override implicit val system: ActorSystem, override imp
     table: TableWithRangeLike[Aws2DynamoDBClient, V, PK, RK],
     pk: PK,
     rk: RKCondition[RK],
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int] = None,
     consistent: Boolean = false,
     overrides: DynamoDBOverride[Client] = DynamoDBOverride.empty
@@ -112,7 +112,7 @@ class PekkoAws2 private (override implicit val system: ActorSystem, override imp
   override def queryPK[V, PK](
     table: Index[Aws2DynamoDBClient, V, PK],
     pk: PK,
-    condition: Option[ConditionExpression[Boolean]],
+    condition: Option[ConditionExpression[V, Boolean]],
     limit: Option[Int],
     consistent: Boolean,
     overrides: DynamoDBOverride[Aws2DynamoDBClient]


### PR DESCRIPTION
## Summary
- Adds `field[V](selector: V => F): Path[V, F]`, a compile-time-checked condition-expression DSL alongside the existing stringly-typed `attr[T](name: String)` — a condition built for one item type can no longer be passed to an operation on a different item type.
- `ConditionExpression[+T]` becomes `ConditionExpression[-V, +T]` (contravariant in `V`), so `attr(...)`/`lit(...)` keep working everywhere with zero call-site changes.
- `field[V](_.selector)` supports single-field and nested-path (`_.a.b`) selectors via two macro backends (Scala 2 blackbox + Scala 3 quotes) behind one shared signature, cross-built for Scala 2.12.19/2.13.18/3.3.8. Nested selectors walk the selector's already-typechecked tree, so every generated `Attr`/`MapIndex` node carries its real type — no runtime casts anywhere in the generated code.

Skål!

Claude Ragnarsson