### PR TITLE
Add UpdateExpression DSL with update/updateAndReturn operations

### DIFF
--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableOps.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/Aws1TableOps.scala
@@ -2,10 +2,10 @@ package com.hiya.alternator.aws1
 
 import cats.syntax.all._
 import com.amazonaws.services.dynamodbv2.model._
-import com.hiya.alternator.internal.{ConditionalSupport, OptApp}
+import com.hiya.alternator.internal.{ConditionalSupport, OptApp, UpdateSupport}
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.{DynamoFormat, ScalarType}
-import com.hiya.alternator.syntax.ConditionExpression
+import com.hiya.alternator.syntax.{ConditionExpression, UpdateExpression}
 import com.hiya.alternator.{BatchReadResult, BatchWriteResult, DynamoDBOverride, Table}
 
 import java.util
@@ -144,6 +144,22 @@ final class Aws1TableOps[V, PK](val underlying: com.hiya.alternator.Table[_, V, 
     overrides(req).asInstanceOf[DeleteItemRequest]
   }
 
+  final def update(
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: Option[com.hiya.alternator.ReturnValue],
+    overrides: DynamoDBOverride.Configure[Aws1DynamoDBClient.OverrideBuilder]
+  ): UpdateItemRequest = {
+    val req = new UpdateItemRequest()
+      .withTableName(underlying.tableName)
+      .withKey(underlying.schema.serializePK(key))
+
+    val rendered = UpdateSupport.eval(req, update, condition, returnValue)
+
+    overrides(rendered).asInstanceOf[UpdateItemRequest]
+  }
+
   final def extractItem(item: DeleteItemResult): Option[Result[V]] = {
     Option(item.getAttributes)
       .filterNot(_.isEmpty)
@@ -154,6 +170,10 @@ final class Aws1TableOps[V, PK](val underlying: com.hiya.alternator.Table[_, V, 
     Option(item.getAttributes)
       .filterNot(_.isEmpty)
       .map(deserialize)
+  }
+
+  final def extractItem(item: UpdateItemResult): Option[Result[V]] = {
+    Option(item.getAttributes).filterNot(_.isEmpty).map(deserialize)
   }
 
   def putRequest(value: V): PutRequest = new PutRequest().withItem(underlying.schema.serializeValue.writeFields(value))

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/internal/Aws1DynamoDB.scala
@@ -10,7 +10,7 @@ import com.hiya.alternator._
 import com.hiya.alternator.aws1._
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.ScalarType
-import com.hiya.alternator.syntax.ConditionExpression
+import com.hiya.alternator.syntax.{ConditionExpression, UpdateExpression}
 
 import java.util
 import java.util.concurrent.{CompletionException, Future => JFuture}
@@ -116,6 +116,51 @@ abstract class Aws1DynamoDB[F[_]: MonadThrow, S[_]] extends DynamoDB[F] {
       table.client.underlying.deleteItemAsync(
         Aws1TableOps(table).delete(key, condition, returnOld = true, overrides = resolvedOverride),
         _: AsyncHandler[DeleteItemRequest, DeleteItemResult]
+      )
+    )
+      .map[ConditionResult[V]](item => ConditionResult.Success(Aws1TableOps(table).extractItem(item)))
+      .recoverWith { case ex: CompletionException => MonadThrow[F].raiseError(ex.getCause) }
+      .recover { case _: model.ConditionalCheckFailedException => ConditionResult.Failed }
+  }
+
+  override def doUpdate[V, PK](
+    table: Table[Aws1DynamoDBClient, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    overrides: DynamoDBOverride[Client]
+  ): F[Boolean] = {
+    val resolvedOverride = (table.overrides |+| overrides)(table.client)
+    async(
+      table.client.underlying.updateItemAsync(
+        Aws1TableOps(table).update(key, update, condition, returnValue = None, overrides = resolvedOverride),
+        _: AsyncHandler[UpdateItemRequest, UpdateItemResult]
+      )
+    )
+      .map(_ => true)
+      .recoverWith { case ex: CompletionException => MonadThrow[F].raiseError(ex.getCause) }
+      .recover { case _: model.ConditionalCheckFailedException => false }
+  }
+
+  override def doUpdateAndReturn[V, PK](
+    table: Table[Aws1DynamoDBClient, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: com.hiya.alternator.ReturnValue,
+    overrides: DynamoDBOverride[Client]
+  ): F[ConditionResult[V]] = {
+    val resolvedOverride = (table.overrides |+| overrides)(table.client)
+    async(
+      table.client.underlying.updateItemAsync(
+        Aws1TableOps(table).update(
+          key,
+          update,
+          condition,
+          returnValue = Some(returnValue),
+          overrides = resolvedOverride
+        ),
+        _: AsyncHandler[UpdateItemRequest, UpdateItemResult]
       )
     )
       .map[ConditionResult[V]](item => ConditionResult.Success(Aws1TableOps(table).extractItem(item)))

--- a/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/package.scala
+++ b/alternator-aws1/src/main/scala/com/hiya/alternator/aws1/package.scala
@@ -56,6 +56,56 @@ package object aws1 {
       builder.withExpressionAttributeValues(attributeValues)
   }
 
+  implicit object UpdateIsConditional extends ConditionalSupport[model.UpdateItemRequest, model.AttributeValue] {
+    override def withConditionExpression(
+      builder: model.UpdateItemRequest,
+      conditionExpression: String
+    ): model.UpdateItemRequest =
+      builder.withConditionExpression(conditionExpression)
+
+    override def withExpressionAttributeNames(
+      builder: model.UpdateItemRequest,
+      attributeNames: JMap[String, String]
+    ): model.UpdateItemRequest =
+      builder.withExpressionAttributeNames(attributeNames)
+
+    override def withExpressionAttributeValues(
+      builder: model.UpdateItemRequest,
+      attributeValues: JMap[String, model.AttributeValue]
+    ): model.UpdateItemRequest =
+      builder.withExpressionAttributeValues(attributeValues)
+  }
+
+  implicit object UpdateIsUpdatable
+    extends com.hiya.alternator.internal.UpdateSupport[model.UpdateItemRequest, model.AttributeValue] {
+    override def withUpdateExpression(
+      builder: model.UpdateItemRequest,
+      updateExpression: String
+    ): model.UpdateItemRequest =
+      builder.withUpdateExpression(updateExpression)
+
+    override def withExpressionAttributeNames(
+      builder: model.UpdateItemRequest,
+      attributeNames: JMap[String, String]
+    ): model.UpdateItemRequest =
+      builder.withExpressionAttributeNames(attributeNames)
+
+    override def withExpressionAttributeValues(
+      builder: model.UpdateItemRequest,
+      attributeValues: JMap[String, model.AttributeValue]
+    ): model.UpdateItemRequest =
+      builder.withExpressionAttributeValues(attributeValues)
+
+    override def withReturnValues(
+      builder: model.UpdateItemRequest,
+      returnValue: com.hiya.alternator.ReturnValue
+    ): model.UpdateItemRequest =
+      builder.withReturnValues(returnValue match {
+        case com.hiya.alternator.ReturnValue.Old => model.ReturnValue.ALL_OLD
+        case com.hiya.alternator.ReturnValue.New => model.ReturnValue.ALL_NEW
+      })
+  }
+
   implicit object ScanIsConditional extends ConditionalSupport[model.ScanRequest, model.AttributeValue] {
     override def withConditionExpression(
       builder: model.ScanRequest,

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/Aws2TableOps.scala
@@ -4,7 +4,7 @@ import cats.syntax.all._
 import com.hiya.alternator.internal._
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.{DynamoFormat, ScalarType}
-import com.hiya.alternator.syntax.ConditionExpression
+import com.hiya.alternator.syntax.{ConditionExpression, UpdateExpression}
 import com.hiya.alternator.{BatchReadResult, BatchWriteResult, DynamoDBOverride, Table}
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration
 import software.amazon.awssdk.services.dynamodb.model._
@@ -167,6 +167,22 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
       .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
   }
 
+  final def update(
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: Option[com.hiya.alternator.ReturnValue],
+    overrides: DynamoDBOverride.Configure[Aws2DynamoDBClient.OverrideBuilder]
+  ): UpdateItemRequest.Builder = {
+    val req = UpdateItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(schema.serializePK(key))
+      .overrideConfiguration(overrides(AwsRequestOverrideConfiguration.builder()).build())
+
+    UpdateSupport.eval(req, update, condition, returnValue)
+  }
+
   final def putRequest(item: V): PutRequest.Builder = {
     PutRequest.builder().item(schema.serializeValue.writeFields(item))
   }
@@ -186,6 +202,12 @@ class Aws2TableOps[V, PK](val underlying: Table[Aws2DynamoDBClient, V, PK]) exte
   }
 
   def extractItem(item: PutItemResponse): Option[Result[V]] = {
+    Option(item.attributes())
+      .filterNot(_.isEmpty)
+      .map(deserialize)
+  }
+
+  def extractItem(item: UpdateItemResponse): Option[Result[V]] = {
     Option(item.attributes())
       .filterNot(_.isEmpty)
       .map(deserialize)

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/internal/Aws2DynamoDB.scala
@@ -7,7 +7,7 @@ import com.hiya.alternator.aws2._
 import com.hiya.alternator.internal._
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.ScalarType
-import com.hiya.alternator.syntax.ConditionExpression
+import com.hiya.alternator.syntax.{ConditionExpression, UpdateExpression}
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration
 import software.amazon.awssdk.services.dynamodb.model
 import software.amazon.awssdk.services.dynamodb.model.{BatchGetItemResponse, KeysAndAttributes, WriteRequest}
@@ -103,6 +103,42 @@ abstract class Aws2DynamoDB[F[+_]: MonadThrow, S[_]] extends DynamoDB[F] {
     val req = Aws2TableOps(table).delete(key, condition, returnOld = true, overrides = resolvedOverride).build()
 
     async(table.client.client.deleteItem(req))
+      .map[ConditionResult[V]](item => ConditionResult.Success(Aws2TableOps(table).extractItem(item)))
+      .recoverWith { case ex: CompletionException => MonadThrow[F].raiseError(ex.getCause) }
+      .recover { case _: model.ConditionalCheckFailedException => ConditionResult.Failed }
+  }
+
+  override protected def doUpdate[V, PK](
+    table: Table[Aws2DynamoDBClient, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    overrides: DynamoDBOverride[Client]
+  ): F[Boolean] = {
+    val resolvedOverride = (table.overrides |+| overrides)(table.client)
+    val req =
+      Aws2TableOps(table).update(key, update, condition, returnValue = None, overrides = resolvedOverride).build()
+    async(table.client.client.updateItem(req))
+      .map(_ => true)
+      .optApp[ConditionExpression[V, Boolean]](f =>
+        _ => f.recover { case _: model.ConditionalCheckFailedException => false }
+      )(condition)
+  }
+
+  override protected def doUpdateAndReturn[V, PK](
+    table: Table[Aws2DynamoDBClient, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: ReturnValue,
+    overrides: DynamoDBOverride[Client]
+  ): F[ConditionResult[V]] = {
+    val resolvedOverride = (table.overrides |+| overrides)(table.client)
+    val req = Aws2TableOps(table)
+      .update(key, update, condition, returnValue = Some(returnValue), overrides = resolvedOverride)
+      .build()
+
+    async(table.client.client.updateItem(req))
       .map[ConditionResult[V]](item => ConditionResult.Success(Aws2TableOps(table).extractItem(item)))
       .recoverWith { case ex: CompletionException => MonadThrow[F].raiseError(ex.getCause) }
       .recover { case _: model.ConditionalCheckFailedException => ConditionResult.Failed }

--- a/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/package.scala
+++ b/alternator-aws2/src/main/scala/com/hiya/alternator/aws2/package.scala
@@ -62,6 +62,51 @@ package object aws2 {
     ): model.DeleteItemRequest.Builder = builder.expressionAttributeValues(attributeValues)
   }
 
+  implicit object UpdateIsConditional
+    extends ConditionalSupport[model.UpdateItemRequest.Builder, model.AttributeValue] {
+    override def withConditionExpression(
+      builder: model.UpdateItemRequest.Builder,
+      conditionExpression: String
+    ): model.UpdateItemRequest.Builder = builder.conditionExpression(conditionExpression)
+
+    override def withExpressionAttributeNames(
+      builder: model.UpdateItemRequest.Builder,
+      attributeNames: JMap[String, String]
+    ): model.UpdateItemRequest.Builder = builder.expressionAttributeNames(attributeNames)
+
+    override def withExpressionAttributeValues(
+      builder: model.UpdateItemRequest.Builder,
+      attributeValues: JMap[String, model.AttributeValue]
+    ): model.UpdateItemRequest.Builder = builder.expressionAttributeValues(attributeValues)
+  }
+
+  implicit object UpdateIsUpdatable
+    extends com.hiya.alternator.internal.UpdateSupport[model.UpdateItemRequest.Builder, model.AttributeValue] {
+    override def withUpdateExpression(
+      builder: model.UpdateItemRequest.Builder,
+      updateExpression: String
+    ): model.UpdateItemRequest.Builder = builder.updateExpression(updateExpression)
+
+    override def withExpressionAttributeNames(
+      builder: model.UpdateItemRequest.Builder,
+      attributeNames: JMap[String, String]
+    ): model.UpdateItemRequest.Builder = builder.expressionAttributeNames(attributeNames)
+
+    override def withExpressionAttributeValues(
+      builder: model.UpdateItemRequest.Builder,
+      attributeValues: JMap[String, model.AttributeValue]
+    ): model.UpdateItemRequest.Builder = builder.expressionAttributeValues(attributeValues)
+
+    override def withReturnValues(
+      builder: model.UpdateItemRequest.Builder,
+      returnValue: com.hiya.alternator.ReturnValue
+    ): model.UpdateItemRequest.Builder =
+      builder.returnValues(returnValue match {
+        case com.hiya.alternator.ReturnValue.Old => model.ReturnValue.ALL_OLD
+        case com.hiya.alternator.ReturnValue.New => model.ReturnValue.ALL_NEW
+      })
+  }
+
   implicit object Aws2LocalDynamoClient extends LocalDynamoClient[Aws2DynamoDBClient] {
     type Config = DynamoDbAsyncClientBuilder
 

--- a/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
+++ b/core/src/main/scala/com/hiya/alternator/DynamoDB.scala
@@ -3,7 +3,7 @@ package com.hiya.alternator
 import cats.{MonadThrow, Traverse}
 import com.hiya.alternator.schema.DynamoFormat.Result
 import com.hiya.alternator.schema.{AttributeValue, DynamoFormat, ScalarType, TableSchema}
-import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment}
+import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, Segment, UpdateExpression}
 
 import scala.collection.compat._
 import scala.jdk.CollectionConverters._
@@ -21,7 +21,7 @@ trait WriteScheduler[F[_]] {
 
 sealed trait ConditionResult[+T]
 object ConditionResult {
-  final case class Success[T](oldValue: Option[DynamoFormat.Result[T]]) extends ConditionResult[T]
+  final case class Success[T](value: Option[DynamoFormat.Result[T]]) extends ConditionResult[T]
   final case object Failed extends ConditionResult[Nothing]
 }
 
@@ -178,7 +178,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
 
   @inline final def putAndReturn[V](table: Table[Client, V, _], value: V): F[Option[DynamoFormat.Result[V]]] =
     doPutAndReturn(table, value, None, DynamoDBOverride.empty).flatMap {
-      case ConditionResult.Success(oldValue) => MonadThrow[F].pure(oldValue)
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
       case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
     }
 
@@ -195,7 +195,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
     overrides: DynamoDBOverride[Client]
   ): F[Option[DynamoFormat.Result[V]]] =
     doPutAndReturn(table, value, None, overrides).flatMap {
-      case ConditionResult.Success(oldValue) => MonadThrow[F].pure(oldValue)
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
       case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
     }
 
@@ -248,7 +248,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
     T: ItemMagnet[T, V, PK]
   ): F[Option[DynamoFormat.Result[V]]] =
     doDeleteAndReturn(table, T.key(key)(table.schema), None, DynamoDBOverride.empty).flatMap {
-      case ConditionResult.Success(oldValue) => MonadThrow[F].pure(oldValue)
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
       case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
     }
 
@@ -267,7 +267,7 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
     T: ItemMagnet[T, V, PK]
   ): F[Option[DynamoFormat.Result[V]]] =
     doDeleteAndReturn(table, T.key(key)(table.schema), None, overrides).flatMap {
-      case ConditionResult.Success(oldValue) => MonadThrow[F].pure(oldValue)
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
       case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
     }
 
@@ -283,6 +283,95 @@ abstract class DynamoDB[F[_]: MonadThrow] extends DynamoDBSource {
     value: Table[Client, V, PK],
     key: PK,
     condition: Option[ConditionExpression[V, Boolean]],
+    overrides: DynamoDBOverride[Client]
+  ): F[ConditionResult[V]]
+
+  @inline final def update[V, PK, T](table: Table[Client, V, PK], key: T, update: UpdateExpression[V])(implicit
+    T: ItemMagnet[T, V, PK]
+  ): F[Unit] =
+    doUpdate(table, T.key(key)(table.schema), update, None, DynamoDBOverride.empty).map(_ => ())
+
+  @inline final def update[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    condition: ConditionExpression[V, Boolean]
+  )(implicit T: ItemMagnet[T, V, PK]): F[Boolean] =
+    doUpdate(table, T.key(key)(table.schema), update, Some(condition), DynamoDBOverride.empty)
+
+  @inline final def update[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    overrides: DynamoDBOverride[Client]
+  )(implicit T: ItemMagnet[T, V, PK]): F[Unit] =
+    doUpdate(table, T.key(key)(table.schema), update, None, overrides).map(_ => ())
+
+  @inline final def update[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    condition: ConditionExpression[V, Boolean],
+    overrides: DynamoDBOverride[Client]
+  )(implicit T: ItemMagnet[T, V, PK]): F[Boolean] =
+    doUpdate(table, T.key(key)(table.schema), update, Some(condition), overrides)
+
+  protected def doUpdate[V, PK](
+    table: Table[Client, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    overrides: DynamoDBOverride[Client]
+  ): F[Boolean]
+
+  @inline final def updateAndReturn[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    returnValue: ReturnValue
+  )(implicit T: ItemMagnet[T, V, PK]): F[Option[DynamoFormat.Result[V]]] =
+    doUpdateAndReturn(table, T.key(key)(table.schema), update, None, returnValue, DynamoDBOverride.empty).flatMap {
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
+      case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
+    }
+
+  @inline final def updateAndReturn[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    condition: ConditionExpression[V, Boolean],
+    returnValue: ReturnValue
+  )(implicit T: ItemMagnet[T, V, PK]): F[ConditionResult[V]] =
+    doUpdateAndReturn(table, T.key(key)(table.schema), update, Some(condition), returnValue, DynamoDBOverride.empty)
+
+  @inline final def updateAndReturn[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    returnValue: ReturnValue,
+    overrides: DynamoDBOverride[Client]
+  )(implicit T: ItemMagnet[T, V, PK]): F[Option[DynamoFormat.Result[V]]] =
+    doUpdateAndReturn(table, T.key(key)(table.schema), update, None, returnValue, overrides).flatMap {
+      case ConditionResult.Success(value) => MonadThrow[F].pure(value)
+      case ConditionResult.Failed => MonadThrow[F].raiseError(new IllegalStateException("Condition failed"))
+    }
+
+  @inline final def updateAndReturn[V, PK, T](
+    table: Table[Client, V, PK],
+    key: T,
+    update: UpdateExpression[V],
+    condition: ConditionExpression[V, Boolean],
+    returnValue: ReturnValue,
+    overrides: DynamoDBOverride[Client]
+  )(implicit T: ItemMagnet[T, V, PK]): F[ConditionResult[V]] =
+    doUpdateAndReturn(table, T.key(key)(table.schema), update, Some(condition), returnValue, overrides)
+
+  protected def doUpdateAndReturn[V, PK](
+    table: Table[Client, V, PK],
+    key: PK,
+    update: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: ReturnValue,
     overrides: DynamoDBOverride[Client]
   ): F[ConditionResult[V]]
 

--- a/core/src/main/scala/com/hiya/alternator/ReturnValue.scala
+++ b/core/src/main/scala/com/hiya/alternator/ReturnValue.scala
@@ -1,0 +1,13 @@
+package com.hiya.alternator
+
+/** Which state of the item `updateAndReturn` reports back: the state immediately before the update (`Old`, maps to
+  * `ReturnValues=ALL_OLD`) or immediately after it (`New`, maps to `ReturnValues=ALL_NEW`). Required with no default on
+  * `updateAndReturn` so every call site states its choice explicitly — unlike `put`/`delete`, `update` can produce a
+  * "new" value that isn't already known locally (the result of server-side arithmetic/list-append/set union), so the
+  * choice actually matters here.
+  */
+sealed trait ReturnValue
+object ReturnValue {
+  case object Old extends ReturnValue
+  case object New extends ReturnValue
+}

--- a/core/src/main/scala/com/hiya/alternator/internal/UpdateSupport.scala
+++ b/core/src/main/scala/com/hiya/alternator/internal/UpdateSupport.scala
@@ -1,0 +1,63 @@
+package com.hiya.alternator.internal
+
+import cats.data.State
+import com.hiya.alternator.ReturnValue
+import com.hiya.alternator.schema.AttributeValue
+import com.hiya.alternator.syntax.{ConditionExpression, UpdateExpression}
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+private[alternator] trait UpdateSupport[Builder, AV] {
+  def withUpdateExpression(builder: Builder, updateExpression: String): Builder
+  def withExpressionAttributeNames(builder: Builder, attributeNames: util.Map[String, String]): Builder
+  def withExpressionAttributeValues(builder: Builder, attributeValues: util.Map[String, AV]): Builder
+  def withReturnValues(builder: Builder, returnValue: ReturnValue): Builder
+}
+
+private[alternator] object UpdateSupport {
+  private def execute[AV, Builder](builder: Builder)(implicit
+    Builder: UpdateSupport[Builder, AV]
+  ): Condition[AV, Builder] =
+    State { params =>
+      val withNames =
+        if (params.attributeNames.nonEmpty) Builder.withExpressionAttributeNames(builder, params.names.asJava)
+        else builder
+      val withValues =
+        if (params.attributeValues.nonEmpty) Builder.withExpressionAttributeValues(withNames, params.values.asJava)
+        else withNames
+      (params, withValues)
+    }
+
+  private def apply[V, Builder, AV: AttributeValue](builder: Builder, expression: UpdateExpression[V])(implicit
+    Builder: UpdateSupport[Builder, AV]
+  ): Condition[AV, Builder] =
+    for {
+      exp <- Condition.renderUpdate(expression)
+      ret <- execute(Builder.withUpdateExpression(builder, exp))
+    } yield ret
+
+  /** Applies the rendered update expression, an optional condition and an optional `ReturnValues` to `builder` in a
+    * single pass. The update and condition expressions '''must''' be rendered within the same `Condition` (`State`)
+    * computation and evaluated with a single `Condition.eval` — rendering them independently would call
+    * `withExpressionAttributeNames`/`withExpressionAttributeValues` twice, and since those calls replace the whole map
+    * on the underlying SDK builder rather than merging into it, the second call would silently discard the first's
+    * names/values instead of the two sharing one map as intended.
+    */
+  def eval[V, Builder, AV: AttributeValue](
+    builder: Builder,
+    expression: UpdateExpression[V],
+    condition: Option[ConditionExpression[V, Boolean]],
+    returnValue: Option[ReturnValue]
+  )(implicit U: UpdateSupport[Builder, AV], C: ConditionalSupport[Builder, AV]): Builder = {
+    val withReturnValue = returnValue.fold(builder)(rv => U.withReturnValues(builder, rv))
+    Condition.eval(
+      for {
+        withUpdate <- apply(withReturnValue, expression)
+        result <- condition.fold(Condition.pure[AV, Builder](withUpdate))(cond =>
+          ConditionalSupport.apply(withUpdate, cond)
+        )
+      } yield result
+    )
+  }
+}

--- a/core/src/main/scala/com/hiya/alternator/internal/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/internal/package.scala
@@ -5,7 +5,7 @@ import cats.data.State
 import cats.syntax.all._
 import com.hiya.alternator.schema.{AttributeValue, TableSchemaWithPartition, TableSchemaWithRange}
 import com.hiya.alternator.syntax.ConditionExpression._
-import com.hiya.alternator.syntax.{ConditionExpression, RKCondition}
+import com.hiya.alternator.syntax.{ConditionExpression, RKCondition, UpdateExpression}
 
 package object internal {
   type Condition[AV, T] = State[ConditionParameters[AV], T]
@@ -60,6 +60,57 @@ package object internal {
             rhs <- renderCondition[AV](rhs)
           } yield s"($lhs) $op ($rhs)"
       }
+
+    /** Renders each non-empty clause bucket via the same `getParam`/`getValue` accumulators `renderCondition` uses (so
+      * an update sharing a request with a `condition` reuses one `ExpressionAttributeNames`/`Values` map), then joins
+      * the present clauses in `SET`/`REMOVE`/`ADD`/`DELETE` order with a space.
+      */
+    def renderUpdate[AV: AttributeValue, V](update: UpdateExpression[V]): Condition[AV, String] = {
+      def clause(keyword: String, items: List[Condition[AV, String]]): Condition[AV, Option[String]] =
+        items match {
+          case Nil => pure(None)
+          case _ => items.sequence.map(rendered => Some(s"$keyword ${rendered.mkString(", ")}"))
+        }
+
+      val setClause = clause(
+        "SET",
+        update.sets.map { action =>
+          for {
+            pathExpr <- renderCondition[AV](action.path)
+            valueExpr <- action.renderValue[AV](pathExpr)
+          } yield s"$pathExpr = $valueExpr"
+        }
+      )
+
+      val removeClause = clause("REMOVE", update.removes.map(renderCondition[AV](_)))
+
+      val addClause = clause(
+        "ADD",
+        update.adds.map { action =>
+          for {
+            pathExpr <- renderCondition[AV](action.path)
+            valueExpr <- getValue(action.value[AV])
+          } yield s"$pathExpr $valueExpr"
+        }
+      )
+
+      val deleteClause = clause(
+        "DELETE",
+        update.deletes.map { action =>
+          for {
+            pathExpr <- renderCondition[AV](action.path)
+            valueExpr <- getValue(action.value[AV])
+          } yield s"$pathExpr $valueExpr"
+        }
+      )
+
+      for {
+        s <- setClause
+        r <- removeClause
+        a <- addClause
+        d <- deleteClause
+      } yield List(s, r, a, d).flatten.mkString(" ")
+    }
 
     private def nonemptyCondition[AV: AttributeValue](
       exp: RKCondition.NonEmpty[_],

--- a/core/src/main/scala/com/hiya/alternator/syntax/ConditionExpression.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/ConditionExpression.scala
@@ -1,6 +1,6 @@
 package com.hiya.alternator.syntax
 
-import com.hiya.alternator.schema.{AttributeValue, ScalarDynamoFormat}
+import com.hiya.alternator.schema.{AttributeValue, DynamoFormat, ScalarDynamoFormat}
 
 sealed trait ConditionExpression[-V, +T]
 
@@ -19,6 +19,13 @@ object ConditionExpression {
   }
 
   sealed trait Path[V, T] extends ConditionExpression[V, T] {
+
+    /** Widens the phantom item type, e.g. so `attr`'s `Path[Any, T]` can be used at a call site typed for a specific
+      * `V2`. Safe because `V`/`V2` are phantom types never inspected at runtime. The `V2 <: V` bound keeps this from
+      * defeating `field[V]`'s type-safety guarantee: an already-precisely-typed `Path[User, T]` cannot be narrowed to
+      * an unrelated `Path[Order, T]`, only widened `Path[Any, T]` can be narrowed to any `V2`.
+      */
+    def narrow[V2 <: V]: Path[V2, T] = this.asInstanceOf[Path[V2, T]]
 
     def get[U](index: Long): Path[V, U] = ArrayIndex[V, U](this, index)
     def get[U](fieldName: String): Path[V, U] = MapIndex[V, U](this, fieldName)
@@ -62,13 +69,13 @@ object ConditionExpression {
 
   private[alternator] final case class Literal[T](
     value: T
-  )(implicit format: ScalarDynamoFormat[T])
+  )(implicit format: DynamoFormat[T])
     extends ConditionExpression[Any, T] {
     def write[AV: AttributeValue]: AV = format.write[AV](value)
   }
 
   private[alternator] object Literal {
-    def apply[T: ScalarDynamoFormat](t: T): Literal[T] = new Literal(t)
+    def apply[T: DynamoFormat](t: T): Literal[T] = new Literal(t)
   }
 
   private[alternator] final case class FunCall[V, T](

--- a/core/src/main/scala/com/hiya/alternator/syntax/UpdateExpression.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/UpdateExpression.scala
@@ -1,0 +1,99 @@
+package com.hiya.alternator.syntax
+
+import cats.kernel.Monoid
+import com.hiya.alternator.internal.Condition
+import com.hiya.alternator.schema.{AttributeValue, DynamoFormat, ScalarDynamoFormat, ScalarType}
+
+/** Flat data holder for a DynamoDB `UpdateExpression`: one list per clause type (`SET`/`REMOVE`/`ADD`/`DELETE`), since
+  * each clause may appear at most once per request, in that fixed order. Compose with cats' `|+|`; it's plain list
+  * concatenation (`Monoid`), not boolean logic, and comes with `combineAll`/`empty` for free.
+  *
+  * '''Known limitation''': the `Monoid` guarantees clause ordering, not path uniqueness — e.g. `set(p, 1) |+|
+  * remove(p)` typechecks but DynamoDB rejects the resulting request at call time.
+  */
+final case class UpdateExpression[V](
+  sets: List[UpdateExpression.SetAction[V, _]],
+  removes: List[ConditionExpression.Path[V, _]],
+  adds: List[UpdateExpression.AddAction[V, _]],
+  deletes: List[UpdateExpression.DeleteAction[V, _]]
+)
+
+object UpdateExpression {
+  implicit def monoid[V]: Monoid[UpdateExpression[V]] = new Monoid[UpdateExpression[V]] {
+    def empty: UpdateExpression[V] = UpdateExpression(Nil, Nil, Nil, Nil)
+    def combine(x: UpdateExpression[V], y: UpdateExpression[V]): UpdateExpression[V] =
+      UpdateExpression(x.sets ++ y.sets, x.removes ++ y.removes, x.adds ++ y.adds, x.deletes ++ y.deletes)
+  }
+
+  private[alternator] sealed trait SetAction[V, T] {
+    def path: ConditionExpression.Path[V, T]
+    def renderValue[AV: AttributeValue](pathExpr: String): Condition[AV, String]
+  }
+
+  private[alternator] final case class Assign[V, T](path: ConditionExpression.Path[V, T], value: T)(implicit
+    format: DynamoFormat[T]
+  ) extends SetAction[V, T] {
+    override def renderValue[AV: AttributeValue](pathExpr: String): Condition[AV, String] =
+      Condition.getValue(format.write[AV](value))
+  }
+
+  private[alternator] final case class ListAppend[V, T](
+    path: ConditionExpression.Path[V, List[T]],
+    values: List[T],
+    prepend: Boolean
+  )(implicit format: DynamoFormat[T])
+    extends SetAction[V, List[T]] {
+    override def renderValue[AV: AttributeValue](pathExpr: String): Condition[AV, String] =
+      Condition.getValue(DynamoFormat.listDynamoFormat[T](format).write[AV](values)).map { valueExpr =>
+        if (prepend) s"list_append($valueExpr, $pathExpr)" else s"list_append($pathExpr, $valueExpr)"
+      }
+  }
+
+  private[alternator] sealed trait AddAction[V, T] {
+    def path: ConditionExpression.Path[V, T]
+    def value[AV: AttributeValue]: AV
+  }
+
+  private[alternator] final case class Increment[V, T](path: ConditionExpression.Path[V, T], delta: T)(implicit
+    format: ScalarDynamoFormat[T]
+  ) extends AddAction[V, T] {
+    override def value[AV: AttributeValue]: AV = format.write[AV](delta)
+  }
+
+  private[alternator] final case class AddToSet[V, T](path: ConditionExpression.Path[V, Set[T]], values: Set[T])(
+    implicit format: ScalarDynamoFormat[T]
+  ) extends AddAction[V, Set[T]] {
+    override def value[AV: AttributeValue]: AV = ScalarSetFormat.write(values)
+  }
+
+  private[alternator] final case class DeleteAction[V, T](path: ConditionExpression.Path[V, Set[T]], values: Set[T])(
+    implicit format: ScalarDynamoFormat[T]
+  ) {
+    def value[AV: AttributeValue]: AV = ScalarSetFormat.write(values)
+  }
+
+  /** Builds the native `SS`/`NS`/`BS` attribute value for a `Set[T]` from just `T`'s `ScalarDynamoFormat`, dispatching
+    * on `attributeType` — there's no generic `DynamoFormat[Set[T]]` instance covering every `ScalarDynamoFormat[T]`
+    * (e.g. `Array[Byte]` only has a `Set[ByteBuffer]` instance), so `ADD`/`DELETE`'s set value is assembled directly
+    * from each element's scalar-written representation instead.
+    */
+  private[alternator] object ScalarSetFormat {
+    def write[AV, T](values: Set[T])(implicit AV: AttributeValue[AV], T: ScalarDynamoFormat[T]): AV = {
+      def unwrap[U](extract: AV => Option[U])(av: AV): U =
+        extract(av).getOrElse(
+          throw new IllegalStateException(s"ScalarDynamoFormat[$T] claims ${T.attributeType} but wrote $av")
+        )
+
+      T.attributeType match {
+        case ScalarType.String =>
+          import scala.jdk.CollectionConverters._
+          AV.createStringSet(values.map(v => unwrap(AV.string)(T.write[AV](v))).asJavaCollection)
+        case ScalarType.Numeric =>
+          import scala.jdk.CollectionConverters._
+          AV.createNumberSet(values.map(v => unwrap(AV.numeric)(T.write[AV](v))).asJavaCollection)
+        case ScalarType.Binary =>
+          AV.createByteBufferSet(values.map(v => unwrap(AV.byteBuffer)(T.write[AV](v))))
+      }
+    }
+  }
+}

--- a/core/src/main/scala/com/hiya/alternator/syntax/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/package.scala
@@ -63,10 +63,17 @@ package object syntax {
     UpdateExpression(Nil, removes = List(path), Nil, Nil)
 
   /** `ADD #p :v` (numeric increment). Native `ADD` is numeric-only, hence `ScalarDynamoFormat` rather than the full
-    * `DynamoFormat`; the `Numeric` bound additionally restricts this builder to genuinely numeric `T`.
+    * `DynamoFormat`; the `Numeric` evidence isn't otherwise needed (DynamoDB does the arithmetic server-side) but is
+    * required as a call-site constraint restricting this builder to genuinely numeric `T` — referencing it below keeps
+    * `-Wunused`/`-Werror` builds from treating it as dead.
     */
-  def increment[V, T: Numeric: ScalarDynamoFormat](path: Path[V, T], delta: T): UpdateExpression[V] =
+  def increment[V, T](path: Path[V, T], delta: T)(implicit
+    N: Numeric[T],
+    F: ScalarDynamoFormat[T]
+  ): UpdateExpression[V] = {
+    val _ = N
     UpdateExpression(Nil, Nil, adds = List(UpdateExpression.Increment(path, delta)), Nil)
+  }
 
   /** `ADD #p :v` (set union). DynamoDB's native Set types (`SS`/`NS`/`BS`) are genuinely scalar-only. */
   def addToSet[V, T: ScalarDynamoFormat](path: Path[V, Set[T]], values: Set[T]): UpdateExpression[V] =

--- a/core/src/main/scala/com/hiya/alternator/syntax/package.scala
+++ b/core/src/main/scala/com/hiya/alternator/syntax/package.scala
@@ -2,6 +2,7 @@ package com.hiya.alternator
 
 import cats.{MonadThrow, Traverse}
 import com.hiya.alternator.schema.{DynamoFormat, ScalarDynamoFormat, StringLikeDynamoFormat}
+import com.hiya.alternator.syntax.ConditionExpression.Path
 
 package object syntax {
 
@@ -42,5 +43,37 @@ package object syntax {
     expr: ConditionExpression[V, Boolean]
   ): ConditionExpression.ConditionExpressionBoolExt[V] =
     new ConditionExpression.ConditionExpressionBoolExt[V](expr)
+
+  /** `SET #p = :v`. Bound on the full `DynamoFormat[T]`, not `ScalarDynamoFormat[T]`, since `SET` accepts any attribute
+    * value including nested maps.
+    */
+  def set[V, T: DynamoFormat](path: Path[V, T], value: T): UpdateExpression[V] =
+    UpdateExpression(sets = List(UpdateExpression.Assign(path, value)), Nil, Nil, Nil)
+
+  /** `SET #p = list_append(#p, :v)`. */
+  def append[V, T: DynamoFormat](path: Path[V, List[T]], values: List[T]): UpdateExpression[V] =
+    UpdateExpression(sets = List(UpdateExpression.ListAppend(path, values, prepend = false)), Nil, Nil, Nil)
+
+  /** `SET #p = list_append(:v, #p)`. */
+  def prepend[V, T: DynamoFormat](path: Path[V, List[T]], values: List[T]): UpdateExpression[V] =
+    UpdateExpression(sets = List(UpdateExpression.ListAppend(path, values, prepend = true)), Nil, Nil, Nil)
+
+  /** `REMOVE #p`. */
+  def remove[V](path: Path[V, _]): UpdateExpression[V] =
+    UpdateExpression(Nil, removes = List(path), Nil, Nil)
+
+  /** `ADD #p :v` (numeric increment). Native `ADD` is numeric-only, hence `ScalarDynamoFormat` rather than the full
+    * `DynamoFormat`; the `Numeric` bound additionally restricts this builder to genuinely numeric `T`.
+    */
+  def increment[V, T: Numeric: ScalarDynamoFormat](path: Path[V, T], delta: T): UpdateExpression[V] =
+    UpdateExpression(Nil, Nil, adds = List(UpdateExpression.Increment(path, delta)), Nil)
+
+  /** `ADD #p :v` (set union). DynamoDB's native Set types (`SS`/`NS`/`BS`) are genuinely scalar-only. */
+  def addToSet[V, T: ScalarDynamoFormat](path: Path[V, Set[T]], values: Set[T]): UpdateExpression[V] =
+    UpdateExpression(Nil, Nil, adds = List(UpdateExpression.AddToSet(path, values)), Nil)
+
+  /** `DELETE #p :v` (set difference). */
+  def removeFromSet[V, T: ScalarDynamoFormat](path: Path[V, Set[T]], values: Set[T]): UpdateExpression[V] =
+    UpdateExpression(Nil, Nil, Nil, deletes = List(UpdateExpression.DeleteAction(path, values)))
 
 }

--- a/core/src/test/scala/com/hiya/alternator/syntax/UpdateExpressionSpec.scala
+++ b/core/src/test/scala/com/hiya/alternator/syntax/UpdateExpressionSpec.scala
@@ -1,0 +1,33 @@
+package com.hiya.alternator.syntax
+
+import cats.kernel.Monoid
+import cats.syntax.all._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class UpdateExpressionSpec extends AnyFunSpec with Matchers {
+  case class Sample(pk: String, count: Int, tags: Set[String], history: List[String], flag: Boolean)
+
+  private val setCount: UpdateExpression[Sample] = set(field[Sample](_.count), 1)
+  private val incrCount: UpdateExpression[Sample] = increment(field[Sample](_.count), 1)
+  private val removeFlag: UpdateExpression[Sample] = remove(field[Sample](_.flag))
+
+  describe("Monoid[UpdateExpression[V]]") {
+    it("has an empty that is a no-op on the left and right") {
+      (Monoid[UpdateExpression[Sample]].empty |+| setCount) shouldBe setCount
+      (setCount |+| Monoid[UpdateExpression[Sample]].empty) shouldBe setCount
+    }
+
+    it("combines associatively") {
+      ((setCount |+| incrCount) |+| removeFlag) shouldBe (setCount |+| (incrCount |+| removeFlag))
+    }
+
+    it("concatenates each clause bucket independently") {
+      val combined = setCount |+| incrCount |+| removeFlag
+      combined.sets shouldBe setCount.sets
+      combined.adds shouldBe incrCount.adds
+      combined.removes shouldBe removeFlag.removes
+      combined.deletes shouldBe empty
+    }
+  }
+}

--- a/integration-tests/base/src/main/scala/com/hiya/alternator/DynamoDBTestBase.scala
+++ b/integration-tests/base/src/main/scala/com/hiya/alternator/DynamoDBTestBase.scala
@@ -19,6 +19,21 @@ object DynamoDBTestBase {
     implicit val schema: TableSchema.Aux[ExampleData, String] =
       TableSchema.schemaWithPK[ExampleData, String]("pk", _.pk)
   }
+
+  case class UpdateData(
+    key: String,
+    count: Int = 0,
+    score: Int = 0,
+    tags: Set[String] = Set.empty,
+    labels: Set[String] = Set.empty,
+    history: List[String] = Nil,
+    flag: Option[Boolean] = None
+  )
+  object UpdateData {
+    implicit val format: RootDynamoFormat[UpdateData] = semiauto.derive
+    implicit val schema: TableSchema.Aux[UpdateData, String] =
+      TableSchema.schemaWithPK[UpdateData, String]("key", _.key)
+  }
 }
 
 abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
@@ -35,6 +50,14 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
 
   protected def eval[T](body: F[T]): T
   protected def list[T](body: S[T]): F[List[T]]
+
+  private def withUpdateTable[T](f: Table[C, UpdateData, String] => F[T]): T = {
+    val tableName = s"test-table-${UUID.randomUUID()}"
+    val table = Table.tableWithPK[UpdateData](tableName).withClient[C](client)
+    eval {
+      LocalDynamoDB.withTable(client, tableName, LocalDynamoDB.schema[UpdateData]).eval(_ => f(table))
+    }
+  }
 
   describe("DynamoDB") {
     it("can read/write items in custom test table") {
@@ -276,6 +299,173 @@ abstract class DynamoDBTestBase[F[_], S[_], C <: DynamoDBClient]
               .map(_ shouldBe ConditionResult.Success(Some(Right(DataPK("new", 1))))) >>
             DB.deleteAndReturn(table, "new", condition = attr("value") === 1).map(_ shouldBe ConditionResult.Failed)
         }
+      }
+    }
+  }
+
+  describe("update") {
+    it("should set a value") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 1)) >>
+          DB.update(table, "u1", set(field[UpdateData](_.count), 42)) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.count) shouldBe Some(42))
+      }
+    }
+
+    it("should append to a list") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", history = List("a"))) >>
+          DB.update(table, "u1", append(field[UpdateData](_.history), List("b", "c"))) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.history) shouldBe Some(List("a", "b", "c")))
+      }
+    }
+
+    it("should prepend to a list") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", history = List("a"))) >>
+          DB.update(table, "u1", prepend(field[UpdateData](_.history), List("x", "y"))) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.history) shouldBe Some(List("x", "y", "a")))
+      }
+    }
+
+    it("should remove an attribute") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", flag = Some(true))) >>
+          DB.update(table, "u1", remove(field[UpdateData](_.flag))) >>
+          DB.get(table, "u1").raiseError.map(_.flatMap(_.flag) shouldBe None)
+      }
+    }
+
+    it("should increment a numeric value") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", score = 10)) >>
+          DB.update(table, "u1", increment(field[UpdateData](_.score), 5)) >>
+          DB.update(table, "u1", increment(field[UpdateData](_.score), -3)) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.score) shouldBe Some(12))
+      }
+    }
+
+    it("should add to a set") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", tags = Set("a"))) >>
+          DB.update(table, "u1", addToSet(field[UpdateData](_.tags), Set("b", "c"))) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.tags) shouldBe Some(Set("a", "b", "c")))
+      }
+    }
+
+    it("should remove from a set") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", tags = Set("a", "b", "c"))) >>
+          DB.update(table, "u1", removeFromSet(field[UpdateData](_.tags), Set("b"))) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.tags) shouldBe Some(Set("a", "c")))
+      }
+    }
+
+    it("should apply a combined multi-action update in one call") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 1, score = 1, tags = Set("a"), labels = Set("x"), flag = Some(true))) >>
+          DB.update(
+            table,
+            "u1",
+            set(field[UpdateData](_.count), 100) |+|
+              append(field[UpdateData](_.history), List("done")) |+|
+              increment(field[UpdateData](_.score), 9) |+|
+              addToSet(field[UpdateData](_.tags), Set("b")) |+|
+              removeFromSet(field[UpdateData](_.labels), Set("x")) |+|
+              remove(field[UpdateData](_.flag))
+          ) >>
+          DB.get(table, "u1").raiseError.map {
+            _ shouldBe Some(
+              UpdateData(
+                "u1",
+                count = 100,
+                score = 10,
+                tags = Set("a", "b"),
+                labels = Set.empty,
+                history = List("done"),
+                flag = None
+              )
+            )
+          }
+      }
+    }
+  }
+
+  describe("update with condition") {
+    it("should succeed when the condition holds") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.update(table, "u1", set(field[UpdateData](_.count), 20), field[UpdateData](_.count) === 10)
+            .map(_ shouldBe true) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.count) shouldBe Some(20))
+      }
+    }
+
+    it("should fail when the condition doesn't hold") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.update(table, "u1", set(field[UpdateData](_.count), 20), field[UpdateData](_.count) === 999)
+            .map(_ shouldBe false) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.count) shouldBe Some(10))
+      }
+    }
+  }
+
+  describe("updateAndReturn") {
+    it("should return the old value with ReturnValue.Old") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.updateAndReturn(table, "u1", set(field[UpdateData](_.count), 20), ReturnValue.Old)
+            .map(_ shouldBe Some(Right(UpdateData("u1", count = 10))))
+      }
+    }
+
+    it("should return the new value with ReturnValue.New") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.updateAndReturn(table, "u1", set(field[UpdateData](_.count), 20), ReturnValue.New)
+            .map(_ shouldBe Some(Right(UpdateData("u1", count = 20))))
+      }
+    }
+
+    it("should return ConditionResult.Success with the requested ReturnValue when the condition holds") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.updateAndReturn(
+            table,
+            "u1",
+            set(field[UpdateData](_.count), 20),
+            field[UpdateData](_.count) === 10,
+            ReturnValue.New
+          ).map(_ shouldBe ConditionResult.Success(Some(Right(UpdateData("u1", count = 20)))))
+      }
+    }
+
+    it("should return ConditionResult.Failed when the condition doesn't hold") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 10)) >>
+          DB.updateAndReturn(
+            table,
+            "u1",
+            set(field[UpdateData](_.count), 20),
+            field[UpdateData](_.count) === 999,
+            ReturnValue.New
+          ).map(_ shouldBe ConditionResult.Failed) >>
+          DB.get(table, "u1").raiseError.map(_.map(_.count) shouldBe Some(10))
+      }
+    }
+  }
+
+  describe("update with overlapping paths") {
+    it("should surface DynamoDB's validation error for a path used in more than one clause") {
+      withUpdateTable { table =>
+        DB.put(table, UpdateData("u1", count = 1)) >>
+          DB.update(
+            table,
+            "u1",
+            set(field[UpdateData](_.count), 2) |+| remove(field[UpdateData](_.count))
+          ).attempt
+            .map(_.isLeft shouldBe true)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds a DynamoDB `UpdateItem` expression DSL (`update`/`updateAndReturn`) covering all four `UpdateExpression` clause types: `SET` (`set`/`append`/`prepend`), `REMOVE` (`remove`), `ADD` (`increment`/`addToSet`), `DELETE` (`removeFromSet`), composable via cats' `Monoid`/`|+|`.
- Adds `ReturnValue` (`Old`/`New`), required on `updateAndReturn` to state old-vs-new state explicitly.
- Renames `ConditionResult.Success.oldValue` → `value` (narrow blast radius: 4 pattern-match sites in `DynamoDB.scala`), since the field can now hold either state depending on the caller's `ReturnValue` choice.
- Implemented once each in `alternator-aws1`/`alternator-aws2`; inherited for free by all six effect-system modules (`cats-aws1/2`, `pekko-aws1/2`, `akka-aws1/2`) via the existing `doPut`/`doDelete` inheritance pattern — zero code changes needed there.

## Test plan
- [x] Core unit tests (Monoid laws) pass on Scala 2.12/2.13/3
- [x] `+Test/compile` green across the full build, all three Scala versions
- [x] New integration test suite (unconditional update per action type, combined multi-action update, conditional success/failure, `updateAndReturn` Old/New, overlapping-path validation error) passes against real LocalStack for cats-aws1/2 and pekko-aws1/2
- [x] Full `test` regression run green, including akka-aws1/2, with zero code changes in those modules

Skål! 🪓

Claude Ragnarsson